### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -23,6 +24,7 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
+
   security-test:
     name: Security tests
     runs-on: ubuntu-latest
@@ -33,8 +35,13 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e security
+
   integration-test:
     name: Integration tests (microk8s)
+    needs:
+      - lint
+      - unit-test
+      - security-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,11 @@ jobs:
 
   integration-test:
     name: Integration tests
+    needs:
+      - lib-check
+      - lint
+      - unit-test
+      - security-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.