### PR TITLE
fix: Update relation endpoints

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -108,7 +108,8 @@ class KafkaConfig:
             set([self.charm.unit] + list(self.charm.model.get_relation(PEER).units))
         )
         hosts = [self.get_host_from_unit(unit=unit) for unit in units]
-        return [f"{host}:9092" for host in hosts]
+        port = 9093 if self.charm.tls.enabled else 9092
+        return [f"{host}:{port}" for host in hosts]
 
     @property
     def kafka_command(self) -> str:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -171,3 +171,19 @@ def check_tls(ip: str, port: int) -> bool:
     # from self-signed certificates. This is indication enough that the server is sending a
     # self-signed key.
     assert "CN = kafka" in result
+
+
+def get_provider_data(unit_name: str, model_full_name: str) -> Dict[str, str]:
+    result = show_unit(unit_name=unit_name, model_full_name=model_full_name)
+    relations_info = result[unit_name]["relation-info"]
+
+    provider_relation_data = {}
+    for info in relations_info:
+        if info["endpoint"] == "kafka-client":
+            provider_relation_data["username"] = info["application-data"]["username"]
+            provider_relation_data["password"] = info["application-data"]["password"]
+            provider_relation_data["endpoints"] = info["application-data"]["endpoints"]
+            provider_relation_data["uris"] = info["application-data"]["uris"]
+            provider_relation_data["zookeeper-uris"] = info["application-data"]["zookeeper-uris"]
+            provider_relation_data["tls"] = info["application-data"]["tls"]
+    return provider_relation_data

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -14,6 +14,7 @@ from tests.integration.helpers import (
     KAFKA_CONTAINER,
     ZK_NAME,
     check_user,
+    get_provider_data,
     get_zookeeper_connection,
     load_acls,
     load_super_users,
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 DUMMY_NAME_1 = "app"
 DUMMY_NAME_2 = "appii"
+TLS_NAME = "tls-certificates-operator"
 
 
 @pytest.fixture(scope="module")
@@ -182,3 +184,28 @@ async def test_remove_application_removes_user_and_acls(ops_test: OpsTest, usern
                 zookeeper_uri=zookeeper_uri,
                 model_full_name=ops_test.model_full_name,
             )
+
+
+@pytest.mark.abort_on_fail
+async def test_connection_updated_on_tls_enabled(ops_test: OpsTest):
+    tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "kafka"}
+    await ops_test.model.deploy(TLS_NAME, channel="edge", config=tls_config)
+    await ops_test.model.add_relation(TLS_NAME, ZK_NAME)
+    await ops_test.model.add_relation(TLS_NAME, APP_NAME)
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, ZK_NAME, TLS_NAME], timeout=1000, idle_period=40
+    )
+
+    assert ops_test.model.applications[APP_NAME].status == "active"
+    assert ops_test.model.applications[ZK_NAME].status == "active"
+    assert ops_test.model.applications[TLS_NAME].status == "active"
+
+    # Check that related application has updated information
+    provider_data = get_provider_data(
+        unit_name="appii/0", model_full_name=ops_test.model_full_name
+    )
+
+    assert provider_data["tls"] == "enabled"
+    assert "9093" in provider_data["uris"]
+    assert "2182" in provider_data["zookeeper-uris"]


### PR DESCRIPTION
# Issue

This PR addresses Jira ticket [DPE-661](https://warthogs.atlassian.net/browse/DPE-661).
Updates relation info on peer-related events.

## Solution

Adds a call on `config_changed` event that updates related application info, if they exist.

## Release Notes

- `src/charm.py`: _on_config_changed_ now updates provider info.
- `src/config.py`: _bootstrap_server_ will change the port depending on TLS status.
- `src/provider.py`: added a method to update information on related applications.

## Testing

Added a test on the provider-suite to check connection information.