### PR TITLE
chore: defer cert events writing to non-connecting container

### DIFF
--- a/src/tls.py
+++ b/src/tls.py
@@ -91,6 +91,10 @@ class KafkaTLS(Object):
             event.defer()
             return
 
+        if not self.charm.container.can_connect():
+            event.defer()
+            return
+
         # avoid setting tls files and restarting
         if event.certificate_signing_request != self.csr:
             logger.error("Can't use certificate, found unknown CSR")


### PR DESCRIPTION
## Changes Made
#### `chore: defer cert events writing to non-connecting container`
- Bundles relate all applications instantly, leading to certificate events triggering before container events
- This would attempt to `push` to the container before the container could connect, and failing