### PR TITLE
test: use pytest unittests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ops >= 1.5.0
+ops >= 1.5.2
 kazoo >= 2.8.0
 tenacity >= 8.0.1
 pure-sasl >= 0.6.2

--- a/src/auth.py
+++ b/src/auth.py
@@ -44,13 +44,12 @@ class KafkaAuth:
             f"zookeeper.connect={self.zookeeper}",
             "--list",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={self.charm.kafka_config.properties_filepath}"]
         acls = run_bin_command(
             container=self.container,
             bin_keyword="acls",
             bin_args=command,
             extra_args=self.opts,
+            zk_tls_config_filepath=self.charm.kafka_config.properties_filepath,
         )
 
         return acls
@@ -164,11 +163,12 @@ class KafkaAuth:
             f"--entity-name={username}",
             f"--add-config=SCRAM-SHA-512=[password={password}]",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={self.charm.kafka_config.properties_filepath}"]
-
         run_bin_command(
-            container=self.container, bin_keyword="configs", bin_args=command, extra_args=self.opts
+            container=self.container,
+            bin_keyword="configs",
+            bin_args=command,
+            extra_args=self.opts,
+            zk_tls_config_filepath=self.charm.kafka_config.properties_filepath,
         )
 
     def delete_user(self, username: str) -> None:
@@ -187,11 +187,12 @@ class KafkaAuth:
             f"--entity-name={username}",
             "--delete-config=SCRAM-SHA-512",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={self.charm.kafka_config.properties_filepath}"]
-
         run_bin_command(
-            container=self.container, bin_keyword="configs", bin_args=command, extra_args=self.opts
+            container=self.container,
+            bin_keyword="configs",
+            bin_args=command,
+            extra_args=self.opts,
+            zk_tls_config_filepath=self.charm.kafka_config.properties_filepath,
         )
 
     def add_acl(
@@ -220,9 +221,6 @@ class KafkaAuth:
             f"--allow-principal=User:{username}",
             f"--operation={operation}",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={self.charm.kafka_config.properties_filepath}"]
-
         if resource_type == "TOPIC":
             command += [f"--topic={resource_name}"]
         if resource_type == "GROUP":
@@ -236,6 +234,7 @@ class KafkaAuth:
             bin_keyword="acls",
             bin_args=command,
             extra_args=self.opts,
+            zk_tls_config_filepath=self.charm.kafka_config.properties_filepath,
         )
 
     def remove_acl(
@@ -261,9 +260,6 @@ class KafkaAuth:
             f"--allow-principal=User:{username}",
             f"--operation={operation}",
         ]
-        if self.charm.tls.enabled:
-            command += [f"--zk-tls-config-file={self.charm.kafka_config.properties_filepath}"]
-
         if resource_type == "TOPIC":
             command += [
                 f"--topic={resource_name}",
@@ -281,6 +277,7 @@ class KafkaAuth:
             bin_keyword="acls",
             bin_args=command,
             extra_args=self.opts,
+            zk_tls_config_filepath=self.charm.kafka_config.properties_filepath,
         )
 
     def remove_all_user_acls(self, username: str) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,7 +79,7 @@ class KafkaK8sCharm(CharmBase):
             "summary": "kafka layer",
             "description": "Pebble config layer for kafka",
             "services": {
-                CHARM_KEY: {
+                CONTAINER: {
                     "override": "replace",
                     "summary": "kafka",
                     "command": self.kafka_config.kafka_command,

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,8 @@ from ops.charm import (
 from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Container, Relation, WaitingStatus
-from ops.pebble import ExecError, Layer, LayerDict, PathError, ProtocolError
+from ops.pebble import ExecError, Layer, PathError, ProtocolError
+from ops import pebble
 
 from auth import KafkaAuth
 from config import KafkaConfig
@@ -67,7 +68,7 @@ class KafkaK8sCharm(CharmBase):
     @property
     def _kafka_layer(self) -> Layer:
         """Returns a Pebble configuration layer for Kafka."""
-        layer_config: LayerDict = {
+        layer_config: pebble.LayerDict = {
             "summary": "kafka layer",
             "description": "Pebble config layer for kafka",
             "services": {

--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional
 
 from ops.model import Container, Unit
 
-from literals import CHARM_KEY, PEER, REL_NAME, ZOOKEEPER_REL_NAME
+from literals import CONTAINER, PEER, REL_NAME, ZOOKEEPER_REL_NAME
 from utils import push
 
 logger = logging.getLogger(__name__)
@@ -36,12 +36,12 @@ class KafkaConfig:
     @property
     def container(self) -> Container:
         """Grabs the current Kafka container."""
-        return getattr(self.charm, "unit").get_container(CHARM_KEY)
+        return getattr(self.charm, "unit").get_container(CONTAINER)
 
     @property
     def sync_password(self) -> Optional[str]:
         """Returns charm-set sync_password for server-server auth between brokers."""
-        return self.charm.get_secret(scope="app", key="sync_password")
+        return self.charm.get_secret(scope="app", key="sync-password")
 
     @property
     def zookeeper_config(self) -> Dict[str, str]:

--- a/src/config.py
+++ b/src/config.py
@@ -7,7 +7,6 @@
 import logging
 from typing import Dict, List, Optional
 
-from ops.charm import CharmBase
 from ops.model import Container, Unit
 
 from literals import CHARM_KEY, PEER, REL_NAME, ZOOKEEPER_REL_NAME
@@ -26,7 +25,7 @@ allow.everyone.if.no.acl.found=false
 class KafkaConfig:
     """Manager for handling Kafka configuration."""
 
-    def __init__(self, charm: CharmBase):
+    def __init__(self, charm):
         self.charm = charm
         self.default_config_path = f"{self.charm.config['data-dir']}/config"
         self.properties_filepath = f"{self.default_config_path}/server.properties"

--- a/src/literals.py
+++ b/src/literals.py
@@ -4,9 +4,10 @@
 
 """Literals used by the Kafka K8s charm."""
 
-CHARM_KEY = "kafka"
+CHARM_KEY = "kafka-k8s"
 PEER = "cluster"
 ZOOKEEPER_REL_NAME = "zookeeper"
 CHARM_USERS = ["sync"]
 REL_NAME = "kafka-client"
 TLS_RELATION = "certificates"
+CONTAINER = "kafka"

--- a/src/provider.py
+++ b/src/provider.py
@@ -18,7 +18,7 @@ from ops.model import Relation
 
 from auth import KafkaAuth
 from config import KafkaConfig
-from literals import CHARM_KEY, PEER, REL_NAME
+from literals import CONTAINER, PEER, REL_NAME
 from utils import generate_password
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class KafkaProvider(Object):
         self.kafka_config = KafkaConfig(self.charm)
         self.kafka_auth = KafkaAuth(
             charm=charm,
-            container=self.charm.unit.get_container(CHARM_KEY),
+            container=self.charm.unit.get_container(CONTAINER),
             opts=[self.kafka_config.extra_args],
             zookeeper=self.kafka_config.zookeeper_config.get("connect", ""),
         )

--- a/src/provider.py
+++ b/src/provider.py
@@ -56,9 +56,12 @@ class KafkaProvider(Object):
         Returns:
             Dict with keys `topic` and `extra_user_roles`
         """
+        if not event.app:
+            return {}
+
         return {
             "extra_user_roles": event.relation.data[event.app].get("extra-user-roles", ""),
-            "topic": event.relation.data[event.app].get("topic"),
+            "topic": event.relation.data[event.app].get("topic", ""),
         }
 
     def provider_relation_config(self, event: RelationEvent) -> Dict[str, str]:
@@ -70,6 +73,9 @@ class KafkaProvider(Object):
         Returns:
             Dict of `username`, `password`, `endpoints`, `uris` and `consumer-group-prefix`
         """
+        if not event.app:
+            return {}
+
         relation = event.relation
 
         username = f"relation-{relation.id}"

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+class DummyExec:
+    def wait_output(self):
+        return ("", None)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -2,7 +2,40 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops.testing import Harness
+
 from auth import Acl, KafkaAuth
+from charm import KafkaK8sCharm
+from literals import CHARM_KEY, CONTAINER, PEER, ZOOKEEPER_REL_NAME
+
+logger = logging.getLogger(__name__)
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(KafkaK8sCharm, meta=METADATA)
+    harness.set_can_connect(CONTAINER, True)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config(
+        {
+            "offsets-retention-minutes": 10080,
+            "log-retention-hours": 168,
+            "auto-create-topics": False,
+        }
+    )
+
+    harness.begin()
+    return harness
 
 
 def test_acl():
@@ -16,7 +49,6 @@ def test_parse_acls():
     acls = """
     Current ACLs for resource `ResourcePattern(resourceType=GROUP, name=relation-81-*, patternType=LITERAL)`:
         (principal=User:relation-81, host=*, operation=READ, permissionType=ALLOW)
-
     Current ACLs for resource `ResourcePattern(resourceType=TOPIC, name=test-topic, patternType=LITERAL)`:
         (principal=User:relation-81, host=*, operation=WRITE, permissionType=ALLOW)
         (principal=User:relation-81, host=*, operation=CREATE, permissionType=ALLOW)
@@ -59,3 +91,108 @@ def test_generate_consumer_acls():
 
     assert sorted(operations) == sorted(set(["READ", "DESCRIBE"]))
     assert sorted(resource_types) == sorted(set(["TOPIC", "GROUP"]))
+
+
+def test_get_acls_tls_adds_zk_tls_flag(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "enabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
+    auth = KafkaAuth(
+        harness.charm,
+        opts=["mordor"],
+        zookeeper="server.1:gandalf.the.grey",
+        container=harness.charm.container,
+    )
+
+    with patch("snap.KafkaSnap.run_bin_command") as patched_bin:
+        auth._get_acls_from_cluster()
+
+        found = False
+        for arg in patched_bin.call_args.kwargs.get("bin_args", []):
+            if "--zk-tls-config-file" in arg:
+                found = True
+
+        assert not found, "--zk-tls-config-file flag not found"
+
+
+def test_add_user_adds_zk_tls_flag(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "enabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
+    auth = KafkaAuth(
+        harness.charm,
+        opts=["mordor"],
+        zookeeper="server.1:gandalf.the.grey",
+        container=harness.charm.container,
+    )
+
+    with patch("subprocess.check_output") as patched:
+        auth.add_user("samwise", "gamgee")
+
+        found = False
+        for arg in patched.call_args.args:
+            if "--zk-tls-config-file" in arg:
+                found = True
+
+        assert found, "--zk-tls-config-file flag not found"
+
+
+def test_delete_user_adds_zk_tls_flag(harness):
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "enabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"tls": "enabled"})
+    auth = KafkaAuth(
+        harness.charm,
+        opts=["mordor"],
+        zookeeper="server.1:gandalf.the.grey",
+        container=harness.charm.container,
+    )
+
+    with patch("subprocess.check_output") as patched:
+        auth.delete_user("samwise")
+
+        found = False
+        for arg in patched.call_args.args:
+            if "--zk-tls-config-file" in arg:
+                found = True
+
+        assert found, "--zk-tls-config-file flag not found"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -294,6 +294,7 @@ def test_config_changed_restarts(harness):
     """Checks units rolling-restat on config changed hook."""
     peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
     harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.update_relation_data(peer_rel_id, harness.charm.unit.name, {"state": "started"})
 
     with patch(
         "config.KafkaConfig.server_properties",
@@ -309,6 +310,8 @@ def test_config_changed_restarts(harness):
         "ops.model.Container.restart"
     ) as patched_restart:
         harness.set_leader(True)
+        with harness.hooks_disabled():
+            harness.container_pebble_ready(CONTAINER)
         harness.charm.on.config_changed.emit()
 
         patched_restart.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -43,7 +43,7 @@ def test_opts_in_pebble_layer(harness):
     """Checks KAFKA_OPTS is present as an env-var in pebble layer."""
     layer = harness.charm._kafka_layer.to_dict()
 
-    assert layer["services"][CHARM_KEY].get("environment", {}).get("KAFKA_OPTS")
+    assert layer["services"][CONTAINER].get("environment", {}).get("KAFKA_OPTS")
 
 
 def test_pebble_ready_waits_until_zookeeper_relation(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import io
+import logging
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+import pytest
+import yaml
+from ops.model import BlockedStatus, WaitingStatus
+from ops.testing import Harness
+from tenacity.wait import wait_none
+
+from charm import KafkaK8sCharm
+from literals import CHARM_KEY, CONTAINER, PEER, REL_NAME, ZOOKEEPER_REL_NAME
+
+logger = logging.getLogger(__name__)
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(KafkaK8sCharm, meta=METADATA)
+    harness.set_can_connect(CONTAINER, True)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config(
+        {
+            "offsets-retention-minutes": 10080,
+            "log-retention-hours": 168,
+            "auto-create-topics": False,
+        }
+    )
+    harness.begin()
+    return harness
+
+
+def test_opts_in_pebble_layer(harness):
+    """Checks KAFKA_OPTS is present as an env-var in pebble layer."""
+    layer = harness.charm._kafka_layer.to_dict()
+
+    assert layer["services"][CHARM_KEY].get("environment", {}).get("KAFKA_OPTS")
+
+
+def test_pebble_ready_waits_until_zookeeper_relation(harness):
+    """Checks unit goes to WaitingStatus without ZK relation on install hook."""
+    harness.container_pebble_ready(CONTAINER)
+    assert isinstance(harness.charm.unit.status, WaitingStatus)
+
+
+def test_leader_elected_sets_passwords(harness):
+    """Checks inter-broker passwords are created on leaderelected hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.set_leader(True)
+
+    assert harness.charm.app_peer_data.get("sync-password", None)
+
+
+def test_zookeeper_joined_sets_chroot(harness):
+    """Checks chroot is added to ZK relation data on ZKrelationjoined hook."""
+    harness.add_relation(PEER, CHARM_KEY)
+    harness.set_leader(True)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+
+    assert CHARM_KEY in harness.charm.model.relations[ZOOKEEPER_REL_NAME][0].data[
+        harness.charm.app
+    ].get("chroot", "")
+
+
+def test_zookeeper_broken_stops_service(harness):
+    """Checks chroot is added to ZK relation data on ZKrelationjoined hook."""
+    harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+
+    with patch("ops.model.Container.stop") as patched_stop:
+        harness.remove_relation(zk_rel_id)
+
+        patched_stop.assert_called_once()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_pebble_ready_defers_without_zookeeper(harness):
+    """Checks event deferred and not lost without ZK relation on pebble_ready hook."""
+    with patch("ops.framework.EventBase.defer") as patched_defer:
+        harness.container_pebble_ready(CONTAINER)
+
+        patched_defer.assert_called_once()
+
+
+def test_pebble_ready_sets_necessary_config(harness):
+    """Checks event writes all needed config to unit on pebble_ready hook."""
+    harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "disabled",
+        },
+    )
+
+    with patch("config.KafkaConfig.set_jaas_config") as patched_jaas, patch(
+        "config.KafkaConfig.set_server_properties"
+    ) as patched_properties:
+        harness.container_pebble_ready(CONTAINER)
+        patched_jaas.assert_called_once()
+        patched_properties.assert_called_once()
+
+
+def test_pebble_ready_sets_auth_and_broker_creds_on_leader(harness):
+    """Checks inter-broker user is created on leader on pebble_ready hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "disabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("auth.KafkaAuth.add_user") as patched_add_user, patch(
+        "config.KafkaConfig.set_jaas_config"
+    ), patch("config.KafkaConfig.set_server_properties"), patch(
+        "charm.broker_active"
+    ) as patched_broker_active:
+        # verify non-leader does not set creds
+        patched_broker_active.retry.wait = wait_none
+        harness.container_pebble_ready(CONTAINER)
+        patched_add_user.assert_not_called()
+        assert not harness.charm.app_peer_data.get("broker-creds", None)
+
+        # verify leader sets creds
+        harness.set_leader(True)
+        harness.container_pebble_ready(CONTAINER)
+        patched_add_user.assert_called_once()
+        assert harness.charm.app_peer_data.get("broker-creds", None)
+
+
+def test_pebble_ready_does_not_start_if_not_ready(harness):
+    """Checks service does not start before ready on pebble_ready hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "disabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
+        "config.KafkaConfig.set_server_properties"
+    ), patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=False
+    ), patch(
+        "ops.framework.EventBase.defer"
+    ) as patched_defer, patch(
+        "ops.model.Container.start"
+    ) as patched_start:
+        harness.container_pebble_ready(CONTAINER)
+
+        patched_start.assert_not_called()
+        patched_defer.assert_called()
+
+
+def test_pebble_ready_does_not_start_if_not_same_tls_as_zk(harness):
+    """Checks service does not start if mismatch Kafka+ZK TLS on pebble_ready hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "enabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("auth.KafkaAuth.add_user"), patch("config.KafkaConfig.set_jaas_config"), patch(
+        "config.KafkaConfig.set_server_properties"
+    ), patch("ops.model.Container.start") as patched_start:
+        harness.container_pebble_ready(CONTAINER)
+
+        patched_start.assert_not_called()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_pebble_ready_does_not_start_if_leader_has_not_set_creds(harness):
+    """Checks service does not start without inter-broker creds on pebble_ready hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
+    harness.add_relation_unit(zk_rel_id, "zookeeper/0")
+    harness.update_relation_data(
+        zk_rel_id,
+        ZOOKEEPER_REL_NAME,
+        {
+            "username": "relation-1",
+            "password": "mellon",
+            "endpoints": "123.123.123",
+            "chroot": "/kafka",
+            "uris": "123.123.123/kafka",
+            "tls": "enabled",
+        },
+    )
+    harness.update_relation_data(peer_rel_id, CHARM_KEY, {"sync-password": "mellon"})
+
+    with patch("config.KafkaConfig.set_jaas_config"), patch(
+        "config.KafkaConfig.set_server_properties"
+    ), patch("ops.model.Container.start") as patched_start:
+        harness.container_pebble_ready(CONTAINER)
+
+        patched_start.assert_not_called()
+        assert isinstance(harness.charm.unit.status, BlockedStatus)
+
+
+def test_config_changed_updates_properties(harness):
+    """Checks that new charm/unit config writes config to unit on config changed hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with patch(
+        "config.KafkaConfig.server_properties",
+        new_callable=PropertyMock,
+        return_value=["gandalf=white"],
+    ), patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch(
+        "ops.model.Container.pull", return_value=io.StringIO("gandalf=grey")
+    ), patch(
+        "config.KafkaConfig.set_server_properties"
+    ) as set_props:
+        harness.charm.on.config_changed.emit()
+
+        set_props.assert_called_once()
+
+
+def test_config_changed_updates_client_data(harness):
+    """Checks that provided relation data updates on config changed hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+    harness.add_relation(REL_NAME, "app")
+
+    with patch(
+        "config.KafkaConfig.server_properties",
+        new_callable=PropertyMock,
+        return_value=["gandalf=white"],
+    ), patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch(
+        "ops.model.Container.pull", return_value=io.StringIO("gandalf=white")
+    ), patch(
+        "provider.KafkaProvider.update_connection_info"
+    ) as patched_update_connection_info:
+        harness.set_leader(True)
+        harness.charm.on.config_changed.emit()
+
+        patched_update_connection_info.assert_called_once()
+
+
+def test_config_changed_restarts(harness):
+    """Checks units rolling-restat on config changed hook."""
+    peer_rel_id = harness.add_relation(PEER, CHARM_KEY)
+    harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
+
+    with patch(
+        "config.KafkaConfig.server_properties",
+        new_callable=PropertyMock,
+        return_value=["gandalf=grey"],
+    ), patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch(
+        "ops.model.Container.pull", return_value=io.StringIO("gandalf=white")
+    ), patch(
+        "utils.push", return_value=None
+    ), patch(
+        "ops.model.Container.restart"
+    ) as patched_restart:
+        harness.set_leader(True)
+        harness.charm.on.config_changed.emit()
+
+        patched_restart.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -74,7 +74,7 @@ def test_zookeeper_joined_sets_chroot(harness):
 
 
 def test_zookeeper_broken_stops_service(harness):
-    """Checks chroot is added to ZK relation data on ZKrelationjoined hook."""
+    """Checks service stops and unit blocks on ZKrelationbroken hook."""
     harness.add_relation(PEER, CHARM_KEY)
     zk_rel_id = harness.add_relation(ZOOKEEPER_REL_NAME, ZOOKEEPER_REL_NAME)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -99,7 +99,7 @@ def test_default_replication_properties_more_than_three(harness):
 def test_auth_properties(zk_relation_id, harness):
     peer_relation_id = harness.charm.model.get_relation("cluster").id
     harness.update_relation_data(
-        peer_relation_id, harness.charm.app.name, {"sync_password": "mellon"}
+        peer_relation_id, harness.charm.app.name, {"sync-password": "mellon"}
     )
     harness.update_relation_data(
         zk_relation_id,

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+import pytest
+import yaml
+from ops.testing import Harness
+
+from charm import KafkaK8sCharm
+from literals import CHARM_KEY, PEER, REL_NAME
+from tests.unit.helpers import DummyExec
+
+logger = logging.getLogger(__name__)
+
+CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
+ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
+METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
+
+
+@pytest.fixture
+def harness():
+    harness = Harness(KafkaK8sCharm, meta=METADATA)
+    harness.add_relation("restart", CHARM_KEY)
+    harness._update_config(
+        {
+            "offsets-retention-minutes": 10080,
+            "log-retention-hours": 168,
+            "auto-create-topics": False,
+        }
+    )
+
+    harness.begin()
+    return harness
+
+
+def test_client_relation_created_defers_if_not_ready(harness):
+    """Checks event is deferred if not ready on clientrelationcreated hook."""
+    with harness.hooks_disabled():
+        harness.add_relation(PEER, CHARM_KEY)
+
+    with patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=False
+    ), patch("auth.KafkaAuth.add_user") as patched_add_user, patch(
+        "ops.framework.EventBase.defer"
+    ) as patched_defer:
+        harness.set_leader(True)
+        harness.add_relation(REL_NAME, "app")
+
+        patched_add_user.assert_not_called()
+        patched_defer.assert_called()
+
+
+def test_client_relation_created_adds_user(harness):
+    """Checks if new users are added on clientrelationcreated hook."""
+    harness.add_relation(PEER, CHARM_KEY)
+    with patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch("auth.KafkaAuth.add_user") as patched_add_user:
+        harness.set_leader(True)
+        client_rel_id = harness.add_relation(REL_NAME, "app")
+
+        patched_add_user.assert_called_once()
+
+        assert harness.charm.peer_relation.data[harness.charm.app].get(f"relation-{client_rel_id}")
+
+
+def test_client_relation_broken_removes_user(harness):
+    """Checks if users are removed on clientrelationbroken hook."""
+    harness.add_relation(PEER, CHARM_KEY)
+    with patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch("auth.KafkaAuth.add_user"), patch(
+        "auth.KafkaAuth.delete_user"
+    ) as patched_delete_user, patch(
+        "auth.KafkaAuth.remove_all_user_acls"
+    ) as patched_remove_acls, patch(
+        "ops.model.Container.exec", return_value=DummyExec()
+    ):
+        harness.set_leader(True)
+        client_rel_id = harness.add_relation(REL_NAME, "app")
+
+        # validating username got added
+        assert harness.charm.peer_relation.data[harness.charm.app].get(f"relation-{client_rel_id}")
+
+        harness.remove_relation(client_rel_id)
+
+        # validating username got removed
+        assert not harness.charm.peer_relation.data[harness.charm.app].get(
+            f"relation-{client_rel_id}"
+        )
+        patched_remove_acls.assert_called_once()
+        patched_delete_user.assert_called_once()
+
+
+def test_client_relation_joined_sets_necessary_relation_data(harness):
+    """Checks if all needed provider relation data is set on clientrelationjoined hook."""
+    harness.add_relation(PEER, CHARM_KEY)
+    with patch(
+        "charm.KafkaK8sCharm.ready_to_start", new_callable=PropertyMock, return_value=True
+    ), patch("auth.KafkaAuth.add_user"), patch(
+        "ops.model.Container.exec", return_value=DummyExec()
+    ), patch(
+        "config.KafkaConfig.zookeeper_connected", new_callable=PropertyMock, return_value=True
+    ), patch(
+        "config.KafkaConfig.zookeeper_config",
+        new_callable=PropertyMock,
+        return_value={"connect": "yes"},
+    ):
+        harness.set_leader(True)
+        client_rel_id = harness.add_relation(REL_NAME, "app")
+        client_relation = harness.charm.model.relations[REL_NAME][0]
+
+        harness.update_relation_data(client_relation.id, "app", {"extra-user-roles": "consumer"})
+        harness.add_relation_unit(client_rel_id, "app/0")
+
+        assert sorted(
+            [
+                "username",
+                "password",
+                "endpoints",
+                "uris",
+                "zookeeper-uris",
+                "consumer-group-prefix",
+                "tls",
+            ]
+        ) == sorted(client_relation.data[harness.charm.app].keys())
+
+        assert client_relation.data[harness.charm.app].get("tls", None) == "disabled"
+        assert client_relation.data[harness.charm.app].get("zookeeper-uris", None) == "yes"
+        assert (
+            client_relation.data[harness.charm.app].get("username", None)
+            == f"relation-{client_rel_id}"
+        )
+        assert (
+            client_relation.data[harness.charm.app].get("consumer-group-prefix", None)
+            == f"relation-{client_rel_id}-"
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -112,7 +112,7 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -126,7 +126,7 @@ commands =
 description = Run scaling integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -140,7 +140,7 @@ commands =
 description = Run provider integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -154,7 +154,7 @@ commands =
 description = Run password rotation integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity
@@ -168,7 +168,7 @@ commands =
 description = Run TLS integration tests
 deps =
     pytest
-    juju
+    juju==2.9.11
     pytest-operator
     kazoo
     tenacity

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8 == 4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
## Changes Made
##### `test: add pytest for unittest framework, expand unittests`
##### `fix: various minor fixes`
- Use `CONTAINER` literal, set `CHARM_KEY` to `kafka-k8s`
- Append `--zk-tls-config-file` flag to bin commands
- Numerous type-hint warnings
- Remove references to `snap` left-over from VM charms
- Use `sync-password` instead of underscored equivalent