### PR TITLE
Fix ruff import sorting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ ignore = ["E501", "D107"]
 extend-exclude = ["__pycache__", "*.egg_info"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104", "E999"]}
 target-version="py310"
+src = ["src", "tests"]
 
 [tool.ruff.mccabe]
 max-complexity = 10

--- a/src/auth.py
+++ b/src/auth.py
@@ -10,6 +10,7 @@ from dataclasses import asdict, dataclass
 from typing import List, Optional, Set
 
 from ops.model import Container
+
 from utils import run_bin_command
 
 logger = logging.getLogger(__name__)

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,10 +7,7 @@
 import logging
 from typing import MutableMapping, Optional
 
-from auth import KafkaAuth
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
-from config import KafkaConfig
-from literals import CHARM_KEY, CHARM_USERS, CONTAINER, PEER, REL_NAME, ZOOKEEPER_REL_NAME
 from ops import pebble
 from ops.charm import (
     ActionEvent,
@@ -25,6 +22,10 @@ from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Container, Relation, WaitingStatus
 from ops.pebble import ExecError, Layer, PathError, ProtocolError
+
+from auth import KafkaAuth
+from config import KafkaConfig
+from literals import CHARM_KEY, CHARM_USERS, CONTAINER, PEER, REL_NAME, ZOOKEEPER_REL_NAME
 from provider import KafkaProvider
 from tls import KafkaTLS
 from utils import broker_active, generate_password

--- a/src/config.py
+++ b/src/config.py
@@ -7,8 +7,9 @@ import logging
 import os
 from typing import Dict, List, Optional
 
-from literals import CONTAINER, PEER, REL_NAME, STORAGE, ZOOKEEPER_REL_NAME
 from ops.model import Container, Unit
+
+from literals import CONTAINER, PEER, REL_NAME, STORAGE, ZOOKEEPER_REL_NAME
 from utils import push
 
 logger = logging.getLogger(__name__)

--- a/src/provider.py
+++ b/src/provider.py
@@ -7,9 +7,6 @@
 import logging
 from typing import Dict
 
-from auth import KafkaAuth
-from config import KafkaConfig
-from literals import CONTAINER, PEER, REL_NAME
 from ops.charm import (
     RelationBrokenEvent,
     RelationChangedEvent,
@@ -18,6 +15,10 @@ from ops.charm import (
 )
 from ops.framework import Object
 from ops.model import Relation
+
+from auth import KafkaAuth
+from config import KafkaConfig
+from literals import CONTAINER, PEER, REL_NAME
 from utils import generate_password
 
 logger = logging.getLogger(__name__)

--- a/src/tls.py
+++ b/src/tls.py
@@ -14,11 +14,12 @@ from charms.tls_certificates_interface.v1.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from literals import TLS_RELATION
 from ops.charm import ActionEvent
 from ops.framework import Object
 from ops.model import Container, Relation
 from ops.pebble import ExecError
+
+from literals import TLS_RELATION
 from utils import generate_password, parse_tls_file, push
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,8 +9,9 @@ from subprocess import PIPE, check_output
 from typing import Any, Dict, List, Set, Tuple
 
 import yaml
-from auth import Acl, KafkaAuth
 from pytest_operator.plugin import OpsTest
+
+from auth import Acl, KafkaAuth
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -9,6 +9,7 @@ import time
 import pytest
 from helpers import APP_NAME, KAFKA_CONTAINER, ZK_NAME, get_kafka_zk_relation_data
 from pytest_operator.plugin import OpsTest
+
 from utils import get_active_brokers
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -8,12 +8,12 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from ops.testing import Harness
+from tests.unit.helpers import DummyExec
+
 from auth import Acl, KafkaAuth
 from charm import KafkaK8sCharm
 from literals import CHARM_KEY, CONTAINER, PEER, ZOOKEEPER_REL_NAME
-from ops.testing import Harness
-
-from tests.unit.helpers import DummyExec
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,9 +4,10 @@
 
 import ops.testing
 import pytest
+from ops.testing import Harness
+
 from charm import KafkaK8sCharm
 from literals import STORAGE
-from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 


### PR DESCRIPTION
Specifies source directories for ruff so imports are split following Python patterns.