### PR TITLE
Move charmed-kafka OCI from DockerHub to GitHub Container Registry

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,7 +20,7 @@ resources:
   kafka-image:
     type: oci-image
     description: OCI Image for Apache Kafka
-    upstream-source: charmed/kafka:3.3.2
+    upstream-source: ghcr.io/canonical/charmed-kafka:3.3.2-22.04_edge
 
 peers:
   cluster:


### PR DESCRIPTION
Closes: [DPE-1561](https://warthogs.atlassian.net/browse/DPE-1561)

# Issue:
Docker is sun-setting Free Team organizations, including https://hub.docker.com/r/charmed

# Solution
Moving to GitHub Container Registry (ghcr.io). OCI Tags are described [here](https://warthogs.atlassian.net/browse/DPE-1502?focusedCommentId=209163).

[DPE-1561]: https://warthogs.atlassian.net/browse/DPE-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ