### PR TITLE
Update GH Actions to the latest version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install tox
         # TODO: Consider replacing with custom image on self-hosted runner OR pinning version
         run: python3 -m pip install tox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.1.0
+        uses: canonical/charming-actions/check-libraries@2.2.3
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -39,10 +39,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.1.0
+        uses: canonical/charming-actions/channel@2.2.3
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.0
+        uses: canonical/charming-actions/upload-charm@2.2.3
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Otherwise the old action ignores ghcr.io registry and failing:

> Run canonical/charming-actions/upload-charm@2.1.0
> /usr/bin/sudo snap install charmcraft --classic --channel latest/stable
> charmcraft 2.2.0 from Canonical** installed
> /usr/bin/sudo charmcraft pack --destructive-mode --quiet
> /usr/bin/docker pull ghcr.io/canonical/charmed-kafka:3.3.2-22.04_edge
> 3.3.2-22.04_edge: Pulling from canonical/charmed-kafka
> 74ac377868f8: Pulling fs layer
> 59df4c571eb5: Pulling fs layer
> fcebd5cdc2a9: Pulling fs layer
> fcebd5cdc2a9: Verifying Checksum
> fcebd5cdc2a9: Download complete
> 74ac377868f8: Verifying Checksum
> 74ac377868f8: Download complete
> 74ac377868f8: Pull complete
> 59df4c571eb5: Verifying Checksum
> 59df4c571eb5: Download complete
> 59df4c571eb5: Pull complete
> fcebd5cdc2a9: Pull complete
> Digest: sha256:2d8a08e3b0194c0f04d18f4a2f261109e91a3100f606950d5cc426897a1a1f2f
> Status: Downloaded newer image for ghcr.io/canonical/charmed-kafka:3.3.2-22.04_edge
> ghcr.io/canonical/charmed-kafka:3.3.2-22.04_edge
> /usr/bin/docker image ls -q canonical/charmed-kafka:3.3.2-22.04_edge
> Error: No digest found for pulled resource_image 'ghcr.io/canonical/charmed-kafka:3.3.2-22.04_edge'
> Error: Error: No digest found for pulled resource_image 'ghcr.io/canonical/charmed-kafka:3.3.2-22.04_edge'

The version 2.2.3 works well on MongoDB K8s operator:
> https://github.com/canonical/mongodb-k8s-operator/actions/runs/4503615211/jobs/7927742440

While here, fix outdated version for `checkout` too.