### PR TITLE
Reintroduce check for container ready

### DIFF
--- a/src/tls.py
+++ b/src/tls.py
@@ -91,6 +91,10 @@ class KafkaTLS(Object):
             event.defer()
             return
 
+        if not self.charm.container.can_connect():
+            event.defer()
+            return
+
         # avoid setting tls files and restarting
         if event.certificate_signing_request != self.csr:
             logger.error("Can't use certificate, found unknown CSR")


### PR DESCRIPTION
This PR reintroduce the check in the certificate available event. CI is really slow and need the container is not ready in time for the event.