### PR TITLE
chore: remove rolling-restart action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -25,9 +25,6 @@ set-tls-private-key:
         Content will be auto-generated if this option is not specified.
         Can be raw-string, or base64 encoded.
 
-rolling-restart-unit:
-  description: Manually triggers a rolling restart for specified units.
-
 get-admin-credentials:
   description: Get administrator authentication credentials for client commands
     The returned client_properties can be used for Kafka bin commands using `--bootstrap-server` and `--command-config` for admin level administration

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,6 @@ class KafkaK8sCharm(TypedCharmBase[CharmConfig]):
         )
 
         self.framework.observe(getattr(self.on, "set_password_action"), self._set_password_action)
-        self.framework.observe(getattr(self.on, "rolling_restart_unit_action"), self._restart)
         self.framework.observe(
             getattr(self.on, "get_admin_credentials_action"), self._get_admin_credentials_action
         )


### PR DESCRIPTION
## Changes Made
`refactor: remove rolling-restart-units action`
- This action was originally added by request of customer teams needing an easy way of applying manual additions to features not yet provided in the base charm, in a safe rolling way
- Since then, a lot of those features have been brought into the core charm, rendering this action redundant
- The description of the method was somewhat confusing, with it's actual usage not being clear
- It also likely does not work as expected since the refactoring of the `_restart()` method no longer rolling itself but instead always restarting the service

## NOTE
- We can add this method back when we commit to supporting Juju 3.X, where the syntax will be clearer:
```bash
# < 3.X
juju run-action rolling-restart-unit kafka/0
juju run-action rolling-restart-unit kafka/1
juju run-action rolling-restart-unit kafka/2

# >= 3.X
juju run rolling-restart --app kafka
```