### PR TITLE
[DPE-1901] Bind pinned image revision

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,7 +21,7 @@ resources:
   kafka-image:
     type: oci-image
     description: OCI Image for Apache Kafka
-    upstream-source: ghcr.io/canonical/charmed-kafka:3-edge
+    upstream-source: ghcr.io/canonical/charmed-kafka@sha256:0c60b132447276dbf1425e6d0ebd353d790dd1a9d49b7c4a1ca6adccfa311f42
 
 peers:
   cluster:


### PR DESCRIPTION
Addressing https://warthogs.atlassian.net/browse/DPE-1901

# Description

We want to bind each charm (Zookeeper, Kafka) on both substrate (K8s, VM) with pinned snap revision and rocks hashes.

Take inspiration from mysql 

* [VM](https://github.com/canonical/mysql-operator/blob/main/src/constants.py#L27)

* [K8s](https://github.com/canonical/mysql-k8s-operator/blob/main/metadata.yaml#L36)

# Acceptance Criteria

All charms are pinned to snap revision and rock hashes