### PR TITLE
[DPE-5262] - docs: add External K8s connection how-to

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -109,6 +109,6 @@ options:
     type: float
     default: 0.8
   expose-external:
-    description: "String to determine how to expose the Kafka cluster externally from the Kubernetes cluster. Possible values: 'nodeport', 'none'"
+    description: "String to determine how to expose the Kafka cluster externally from the Kubernetes cluster. Possible values: 'nodeport', 'false'"
     type: string
-    default: "nodeport"
+    default: "false"

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -16,7 +16,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DataPeerUnitData,
 )
 from charms.zookeeper.v0.client import QuorumLeaderNotFoundError, ZooKeeperManager
-from kazoo.client import AuthFailedError, NoNodeError
+from kazoo.client import AuthFailedError, ConnectionLoss, NoNodeError
 from lightkube.resources.core_v1 import Node, Pod
 from ops.model import Application, Relation, Unit
 from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
@@ -713,7 +713,7 @@ class ZooKeeper(RelationState):
         zk = ZooKeeperManager(hosts=hosts, username=self.username, password=self.password)
         try:
             brokers = zk.leader_znodes(path=path)
-        except (NoNodeError, AuthFailedError, QuorumLeaderNotFoundError) as e:
+        except (NoNodeError, AuthFailedError, QuorumLeaderNotFoundError, ConnectionLoss) as e:
             logger.debug(str(e))
             brokers = set()
 

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -238,7 +238,10 @@ class CharmConfig(BaseConfigModel):
         if SUBSTRATE == "vm":
             return
 
-        if value == "none":
+        if value not in ["false", "nodeport"]:
+            raise ValueError("Value not one of 'false' or 'nodeport'")
+
+        if value == "false":
             return
 
         return value

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -85,6 +85,7 @@ async def test_build_and_deploy(ops_test: OpsTest, kafka_charm, app_charm):
             num_units=1,
             resources={"kafka-image": KAFKA_CONTAINER},
             trust=True,
+            config={"expose-external": "nodeport"},
         ),
         ops_test.model.deploy(ZK_NAME, channel="3/edge", num_units=1, trust=True),
         ops_test.model.deploy(app_charm, application_name=DUMMY_NAME, trust=True),
@@ -123,6 +124,7 @@ async def test_multi_cluster_isolation(ops_test: OpsTest, kafka_charm):
             num_units=1,
             resources={"kafka-image": KAFKA_CONTAINER},
             trust=True,
+            config={"expose-external": "nodeport"},
         ),
         ops_test.model.deploy(
             ZK_NAME, application_name=second_zk_name, channel="3/edge", trust=True

--- a/tests/integration/test_balancer.py
+++ b/tests/integration/test_balancer.py
@@ -52,6 +52,7 @@ class TestBalancer:
                 config={
                     "roles": "broker,balancer" if self.balancer_app == APP_NAME else "broker",
                     "profile": "testing",
+                    "expose-external": "nodeport",
                 },
                 resources={"kafka-image": KAFKA_CONTAINER},
                 trust=True,
@@ -88,6 +89,7 @@ class TestBalancer:
                 config={
                     "roles": self.balancer_app,
                     "profile": "testing",
+                    "expose-external": "nodeport",
                 },
                 resources={"kafka-image": KAFKA_CONTAINER},
                 trust=True,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -28,6 +28,7 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, kafka_charm):
     await asyncio.gather(
         ops_test.model.deploy(
@@ -69,6 +70,7 @@ async def test_consistency_between_workload_and_metadata(ops_test: OpsTest):
     assert application.data.get("workload-version", "") == DEPENDENCIES["kafka_service"]["version"]
 
 
+@pytest.mark.abort_on_fail
 async def test_remove_zk_relation_relate(ops_test: OpsTest):
     remove_relation_cmd = f"remove-relation {APP_NAME} {ZK_NAME}"
     await ops_test.juju(*remove_relation_cmd.split(), check=True)
@@ -80,7 +82,11 @@ async def test_remove_zk_relation_relate(ops_test: OpsTest):
     await ops_test.model.add_relation(APP_NAME, ZK_NAME)
     async with ops_test.fast_forward(fast_interval="60s"):
         await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, ZK_NAME], status="active", idle_period=30, timeout=1000
+            apps=[APP_NAME, ZK_NAME],
+            status="active",
+            idle_period=30,
+            timeout=1000,
+            raise_on_error=False,
         )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -43,6 +43,7 @@ async def test_build_and_deploy(ops_test: OpsTest, kafka_charm):
             num_units=1,
             resources={"kafka-image": KAFKA_CONTAINER},
             trust=True,
+            config={"expose-external": "nodeport"},
         ),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)

--- a/tests/integration/test_password_rotation.py
+++ b/tests/integration/test_password_rotation.py
@@ -36,6 +36,7 @@ async def test_build_and_deploy(ops_test: OpsTest, kafka_charm):
             resources={"kafka-image": KAFKA_CONTAINER},
             num_units=1,
             trust=True,
+            config={"expose-external": "nodeport"},
         ),
     )
     await ops_test.model.block_until(lambda: len(ops_test.model.applications[ZK_NAME].units) == 3)

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -51,6 +51,7 @@ async def test_deploy_charms_relate_active(
             num_units=1,
             resources={"kafka-image": KAFKA_CONTAINER},
             trust=True,
+            config={"expose-external": "nodeport"},
         ),
         ops_test.model.deploy(app_charm, application_name=DUMMY_NAME_1, num_units=1, trust=True),
     )

--- a/tests/integration/test_scaling.py
+++ b/tests/integration/test_scaling.py
@@ -32,6 +32,7 @@ async def test_kafka_simple_scale_up(ops_test: OpsTest, kafka_charm):
             num_units=1,
             resources={"kafka-image": KAFKA_CONTAINER},
             trust=True,
+            config={"expose-external": "nodeport"},
         ),
     )
     await ops_test.model.wait_for_idle(apps=[APP_NAME, ZK_NAME])

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -50,7 +50,8 @@ async def test_deploy_tls(ops_test: OpsTest, kafka_charm, app_charm):
             application_name=APP_NAME,
             resources={"kafka-image": KAFKA_CONTAINER},
             config={
-                "ssl_principal_mapping_rules": "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT"
+                "ssl_principal_mapping_rules": "RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT",
+                "expose-external": "nodeport",
             },
             trust=True,
         ),

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -94,7 +94,7 @@ async def test_kafka_tls(ops_test: OpsTest, app_charm):
         )
 
         # Unit is on 'blocked' but whole app is on 'waiting'
-        assert ops_test.model.applications[APP_NAME].status == "waiting"
+        assert ops_test.model.applications[APP_NAME].status in ["waiting", "blocked"]
 
     # Set a custom private key, by running set-tls-private-key action with no parameters,
     # as this will generate a random one

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -124,3 +124,15 @@ def patched_node_ip():
             yield patched_node_ip
     else:
         yield
+
+
+@pytest.fixture(autouse=True)
+def patched_node_port():
+    if SUBSTRATE == "k8s":
+        with patch(
+            "managers.k8s.K8sManager.get_listener_nodeport",
+            return_value=20000,
+        ) as patched_node_port:
+            yield patched_node_port
+    else:
+        yield

--- a/tests/unit/scenario/test_balancer.py
+++ b/tests/unit/scenario/test_balancer.py
@@ -158,7 +158,6 @@ def test_ready_to_start_no_peer_cluster(charm_configuration):
 def test_ready_to_start_no_zk_data(charm_configuration, base_state: State):
     # Given
     charm_configuration["options"]["roles"]["default"] = "balancer,broker"
-    charm_configuration["options"]["expose-external"]["default"] = "none"
     ctx = Context(
         KafkaCharm,
         meta=METADATA,
@@ -183,7 +182,6 @@ def test_ready_to_start_no_zk_data(charm_configuration, base_state: State):
 def test_ready_to_start_no_broker_data(charm_configuration, base_state: State, zk_data):
     # Given
     charm_configuration["options"]["roles"]["default"] = "balancer,broker"
-    charm_configuration["options"]["expose-external"]["default"] = "none"
     ctx = Context(
         KafkaCharm,
         meta=METADATA,
@@ -206,7 +204,6 @@ def test_ready_to_start_no_broker_data(charm_configuration, base_state: State, z
 def test_ready_to_start_ok(charm_configuration, base_state: State, zk_data):
     # Given
     charm_configuration["options"]["roles"]["default"] = "balancer,broker"
-    charm_configuration["options"]["expose-external"]["default"] = "none"
     ctx = Context(
         KafkaCharm, meta=METADATA, config=charm_configuration, actions=ACTIONS, unit_id=0
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -52,7 +52,6 @@ def harness() -> Harness:
         {
             "log_retention_ms": "-1",
             "compression_type": "producer",
-            "expose-external": "none",
         }
     )
     harness.begin()

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -34,7 +34,6 @@ def harness():
         {
             "log_retention_ms": "-1",
             "compression_type": "producer",
-            "expose-external": "none",
         }
     )
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -33,7 +33,6 @@ def harness():
         {
             "log_retention_ms": "-1",
             "compression_type": "producer",
-            "expose-external": "none",
         }
     )
     harness.begin()

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -48,7 +48,6 @@ def harness(zk_data):
         {
             "log_retention_ms": "-1",
             "compression_type": "producer",
-            "expose-external": "none",
         }
     )
     harness.begin()


### PR DESCRIPTION
## Changes Made
#### `docs: add External K8s connection How-To`
- Overview of the various NodePort services that can be created
- Short guide on how to enable NodePort access
- Quick overview of making client connections through a `bootstrap` service with Kafka generally
#### `docs: update listeners reference to include CLIENT/EXTERNAL and OAUTHBEARER`
- Docs didn't include OAUTHBEARER feature
- Changed the use of EXTERNAL to mean 'k8s-external', with CLIENT being the new 'k8s-internal, but not internal to the charm'
#### `chore: default expose-external=false`
- Have set `expose-external=nodeport` in all our integration tests, as they will test the nodeport feature implicitly when making client connections between apps
#### `test: update listeners unit-test to test for EXTERNAL`
- This was probably not tested sufficiently before, is present now in existing listener test