### PR TITLE
[DPE-5208] - fix: secure written znodes

### DIFF
--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -317,6 +317,7 @@ class ConfigManager(CommonConfigManager):
         return [
             f"broker.id={self.state.unit_broker.unit_id}",
             f"zookeeper.connect={self.state.zookeeper.connect}",
+            "zookeeper.set.acl=true",
         ]
 
     @property

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -28,7 +28,6 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, kafka_charm):
     await asyncio.gather(
         ops_test.model.deploy(
@@ -69,7 +68,6 @@ async def test_consistency_between_workload_and_metadata(ops_test: OpsTest):
     assert application.data.get("workload-version", "") == DEPENDENCIES["kafka_service"]["version"]
 
 
-@pytest.mark.abort_on_fail
 async def test_remove_zk_relation_relate(ops_test: OpsTest):
     remove_relation_cmd = f"remove-relation {APP_NAME} {ZK_NAME}"
     await ops_test.juju(*remove_relation_cmd.split(), check=True)


### PR DESCRIPTION
## Changes Made
#### `fix: set ACLs on written zNodes`
- Fixes https://github.com/canonical/kafka-operator/issues/230
- ZooKeeper ACLs are not recursive, meaning that any written data to a zNode nested under the `chroot`, will be readable by all
- Setting`zookeeper.set.acl=true` ensures that there are protections on the zNodes written by Kafka 