### PR TITLE
[DPE-6011] - feat: reconcile vm+k8s feature drift

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,8 @@ jobs:
           - integration-upgrade
           - integration-balancer-single
           - integration-balancer-multi
+          - integration-kraft-single
+          - integration-kraft-multi
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/actions.yaml
+++ b/actions.yaml
@@ -36,6 +36,9 @@ get-admin-credentials:
     The returned client_properties can be used for Kafka bin commands using `--bootstrap-server` and `--command-config` for admin level administration
     This action must be called on the leader unit.
 
+get-listeners:
+  description: Get all active listeners and their port allocations
+
 rebalance:
   description: Trigger a rebalance of cluster partitions based on configured goals
   params:

--- a/config.yaml
+++ b/config.yaml
@@ -92,6 +92,10 @@ options:
     description: Config options to add extra-sans to the ones used when requesting server certificates. The extra-sans are specified by comma-separated names to be added when requesting signed certificates. Use "{unit}" as a placeholder to be filled with the unit number, e.g. "worker-{unit}" will be translated as "worker-0" for unit 0 and "worker-1" for unit 1 when requesting the certificate.
     type: string
     default: ""
+  extra_listeners:
+    description: "Config options to add extra SANs to the ones used when requesting server certificates, and to define custom `advertised.listeners` and ports for clients external to the Juju model. These items are comma-separated. Use '{unit}' as a placeholder to be filled with the unit number if necessary. For port allocations, providing the port for a given listener will offset the generated port number by that amount, with an accepted value range of 20001-50000. For example, a provided value of 'worker-{unit}.domain.com:30000' will generate listeners for unit 0 with name 'worker-0.domain.com', and be allocated ports 39092, 39093 etc for each authentication scheme."
+    type: string
+    default: ""
   log_level:
     description: "Level of logging for the different components operated by the charm. Possible values: ERROR, WARNING, INFO, DEBUG"
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ options:
   roles:
     description: |
       Comma separated list of the roles assigned to the nodes of this cluster.
-      This configuration accepts the following roles: 'broker' (standard functionality), 'balancer' (cruise control).
+      This configuration accepts the following roles: 'broker' (standard functionality), 'balancer' (cruise control), 'controller' (KRaft mode).
     type: string
     default: broker
   compression_type:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,7 +34,7 @@ resources:
   kafka-image:
     type: oci-image
     description: OCI Image for Apache Kafka
-    upstream-source: ghcr.io/canonical/charmed-kafka@sha256:67d2729ca6c4f158682c481a512c37e555bae6edc30e8f0acdb0460fcbeffe88
+    upstream-source: ghcr.io/canonical/charmed-kafka@sha256:0f180540572828e3152ab6a39b80891c6dfb2d6abc79914ec19646e6b487b1c8
 
 peers:
   cluster:

--- a/src/charm.py
+++ b/src/charm.py
@@ -99,7 +99,10 @@ class KafkaCharm(TypedCharmBase[CharmConfig]):
         This handler is in charge of stopping the workloads, since the sub-operators would not
         be instantiated if roles are changed.
         """
-        if not self.state.runs_broker and self.broker.workload.active():
+        if (
+            not (self.state.runs_broker or self.state.runs_controller)
+            and self.broker.workload.active()
+        ):
             self.broker.workload.stop()
 
         if (

--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -23,6 +23,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
 from lightkube.core.exceptions import ApiError as LightKubeApiError
 from ops import Object, Relation
 from ops.model import Unit
+from tenacity import retry, retry_if_exception_cause_type, stop_after_attempt, wait_fixed
 
 from core.models import (
     BrokerCapacities,
@@ -367,6 +368,12 @@ class ClusterState(Object):
         return enabled_auth
 
     @property
+    @retry(
+        wait=wait_fixed(5),
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_cause_type(LightKubeApiError),
+        reraise=True,
+    )
     def bootstrap_servers_external(self) -> str:
         """Comma-delimited string of `bootstrap-server` for external access."""
         return ",".join(

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -503,14 +503,6 @@ class KafkaBroker(RelationState):
 
         return addr
 
-    @property
-    def host(self) -> str:
-        """Return the hostname of a unit."""
-        if self.substrate == "vm":
-            return self.internal_address
-        else:
-            return self.node_ip or self.internal_address
-
     # --- TLS ---
 
     @property
@@ -756,7 +748,7 @@ class ZooKeeper(RelationState):
     # retry to give ZK time to update its broker zNodes before failing
     @retry(
         wait=wait_fixed(5),
-        stop=stop_after_attempt(3),
+        stop=stop_after_attempt(10),
         retry=retry_if_result(lambda result: result is False),
         retry_error_callback=lambda _: False,
     )

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -93,6 +93,8 @@ class PeerCluster(RelationState):
         broker_username: str = "",
         broker_password: str = "",
         broker_uris: str = "",
+        cluster_uuid: str = "",
+        controller_quorum_uris: str = "",
         racks: int = 0,
         broker_capacities: BrokerCapacities = {},
         zk_username: str = "",
@@ -106,6 +108,8 @@ class PeerCluster(RelationState):
         self._broker_username = broker_username
         self._broker_password = broker_password
         self._broker_uris = broker_uris
+        self._cluster_uuid = cluster_uuid
+        self._controller_quorum_uris = controller_quorum_uris
         self._racks = racks
         self._broker_capacities = broker_capacities
         self._zk_username = zk_username
@@ -173,6 +177,38 @@ class PeerCluster(RelationState):
             relation=self.relation,
             fields=BALANCER.requested_secrets,
         ).get("broker-uris", "")
+
+    @property
+    def controller_quorum_uris(self) -> str:
+        """The quorum voters in KRaft mode."""
+        if self._controller_quorum_uris:
+            return self._controller_quorum_uris
+
+        if not self.relation or not self.relation.app:
+            return ""
+
+        return (
+            self.data_interface.fetch_relation_field(
+                relation_id=self.relation.id, field="controller-quorum-uris"
+            )
+            or ""
+        )
+
+    @property
+    def cluster_uuid(self) -> str:
+        """The cluster uuid used to format storages in KRaft mode."""
+        if self._cluster_uuid:
+            return self._cluster_uuid
+
+        if not self.relation or not self.relation.app:
+            return ""
+
+        return (
+            self.data_interface.fetch_relation_field(
+                relation_id=self.relation.id, field="cluster-uuid"
+            )
+            or ""
+        )
 
     @property
     def racks(self) -> int:
@@ -303,6 +339,7 @@ class PeerCluster(RelationState):
     @property
     def broker_connected(self) -> bool:
         """Checks if there is an active broker relation with all necessary data."""
+        # FIXME rename to specify balancer-broker connection
         if not all(
             [
                 self.broker_username,
@@ -315,6 +352,14 @@ class PeerCluster(RelationState):
                 # rack is optional, empty if not rack-aware
             ]
         ):
+            return False
+
+        return True
+
+    @property
+    def broker_connected_kraft_mode(self) -> bool:
+        """Checks for necessary data required by a controller."""
+        if not all([self.broker_username, self.broker_password, self.cluster_uuid]):
             return False
 
         return True
@@ -406,6 +451,16 @@ class KafkaCluster(RelationState):
     def balancer_uris(self) -> str:
         """Persisted balancer uris."""
         return self.relation_data.get("balancer-uris", "")
+
+    @property
+    def controller_quorum_uris(self) -> str:
+        """Persisted controller quorum voters."""
+        return self.relation_data.get("controller-quorum-uris", "")
+
+    @property
+    def cluster_uuid(self) -> str:
+        """Cluster uuid used for initializing storages."""
+        return self.relation_data.get("cluster-uuid", "")
 
 
 class KafkaBroker(RelationState):

--- a/src/core/structured_config.py
+++ b/src/core/structured_config.py
@@ -10,7 +10,7 @@ from enum import Enum
 from charms.data_platform_libs.v0.data_models import BaseConfigModel
 from pydantic import Field, validator
 
-from literals import BALANCER, BROKER, SUBSTRATE
+from literals import BALANCER, BROKER, CONTROLLER, SUBSTRATE
 
 logger = logging.getLogger(__name__)
 
@@ -264,7 +264,7 @@ class CharmConfig(BaseConfigModel):
         """Check roles values."""
         roles = set(map(str.strip, value.split(",")))
 
-        if unknown_roles := roles - {BROKER.value, BALANCER.value}:
+        if unknown_roles := roles - {BROKER.value, BALANCER.value, CONTROLLER.value}:
             raise ValueError("Unknown role(s):", unknown_roles)
 
         return ",".join(sorted(roles))  # this has to be a string as it goes in to properties

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -111,10 +111,11 @@ class BalancerOperator(Object):
             payload = {
                 "balancer-username": BALANCER_WEBSERVER_USER,
                 "balancer-password": self.charm.workload.generate_password(),
-                "balancer-uris": f"{self.charm.state.unit_broker.host}:{BALANCER_WEBSERVER_PORT}",
+                "balancer-uris": f"{self.charm.state.unit_broker.internal_address}:{BALANCER_WEBSERVER_PORT}",
             }
             # Update relation data intra & extra cluster (if it exists)
             self.charm.state.cluster.update(payload)
+
             if self.charm.state.peer_cluster_orchestrator:
                 self.charm.state.peer_cluster_orchestrator.update(payload)
 

--- a/src/events/balancer.py
+++ b/src/events/balancer.py
@@ -169,7 +169,7 @@ class BalancerOperator(Object):
                 content_changed = True
 
         # On k8s, adding/removing a broker does not change the bootstrap server property if exposed by nodeport
-        broker_capacities = self.charm.state.balancer.broker_capacities
+        broker_capacities = self.charm.state.peer_cluster.broker_capacities
         if (
             file_content := json.loads(
                 "".join(self.workload.read(self.workload.paths.capacity_jbod_json))
@@ -200,8 +200,8 @@ class BalancerOperator(Object):
             available_brokers = [broker.unit_id for broker in self.charm.state.brokers]
         else:
             brokers = (
-                [broker.name for broker in self.charm.state.balancer.relation.units]
-                if self.charm.state.balancer.relation
+                [broker.name for broker in self.charm.state.peer_cluster.relation.units]
+                if self.charm.state.peer_cluster.relation
                 else []
             )
             available_brokers = [int(broker.split("/")[1]) for broker in brokers]

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import warnings
 from typing import TYPE_CHECKING
 
 from charms.tls_certificates_interface.v1.tls_certificates import (
@@ -151,7 +152,9 @@ class TLSHandler(Object):
             relation_id=event.relation.id,
         )
         subject = (
-            os.uname()[1] if self.charm.substrate == "k8s" else self.charm.state.unit_broker.host
+            os.uname()[1]
+            if self.charm.substrate == "k8s"
+            else self.charm.state.unit_broker.internal_address
         )
         sans = self.charm.broker.tls_manager.build_sans()
         csr = (
@@ -293,6 +296,13 @@ class TLSHandler(Object):
             return
 
         sans = self.charm.broker.tls_manager.build_sans()
+
+        # only warn during certificate creation, not every event if in structured_config
+        if self.charm.config.certificate_extra_sans:
+            warnings.warn(
+                "'certificate_extra_sans' config option is deprecated, use 'extra_listeners' instead",
+                DeprecationWarning,
+            )
 
         csr = generate_csr(
             private_key=self.charm.state.unit_broker.private_key.encode("utf-8"),

--- a/src/literals.py
+++ b/src/literals.py
@@ -66,11 +66,12 @@ class Ports:
     client: int
     internal: int
     external: int
+    extra: int = 0
 
 
 AuthProtocol = Literal["SASL_PLAINTEXT", "SASL_SSL", "SSL"]
 AuthMechanism = Literal["SCRAM-SHA-512", "OAUTHBEARER", "SSL"]
-Scope = Literal["INTERNAL", "CLIENT", "EXTERNAL"]
+Scope = Literal["INTERNAL", "CLIENT", "EXTERNAL", "EXTRA"]
 AuthMap = NamedTuple("AuthMap", protocol=AuthProtocol, mechanism=AuthMechanism)
 
 SECURITY_PROTOCOL_PORTS: dict[AuthMap, Ports] = {

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -238,12 +238,20 @@ class AuthManager:
         ]
 
         if resource_type == "TOPIC":
-            command += [f"--topic={resource_name}"]
+            if len(resource_name) > 3 and resource_name.endswith("*"):
+                pattern = "PREFIXED"
+                resource_name = resource_name[:-1]
+            else:
+                pattern = "LITERAL"
+
+            command += [f"--topic={resource_name}", f"--resource-pattern-type={pattern}"]
+
         if resource_type == "GROUP":
             command += [
                 f"--group={resource_name}",
                 "--resource-pattern-type=PREFIXED",
             ]
+        logger.info(f"CREATE ACL - {command}")
         self.workload.run_bin_command(bin_keyword="acls", bin_args=command, opts=[self.log4j_opts])
 
     def remove_acl(
@@ -272,7 +280,14 @@ class AuthManager:
         ]
 
         if resource_type == "TOPIC":
-            command += [f"--topic={resource_name}"]
+            if len(resource_name) > 3 and resource_name.endswith("*"):
+                pattern = "PREFIXED"
+                resource_name = resource_name[:-1]
+            else:
+                pattern = "LITERAL"
+
+            command += [f"--topic={resource_name}", f"--resource-pattern-type={pattern}"]
+
         if resource_type == "GROUP":
             command += [
                 f"--group={resource_name}",

--- a/src/managers/balancer.py
+++ b/src/managers/balancer.py
@@ -137,8 +137,8 @@ class BalancerManager:
     def cruise_control(self) -> CruiseControlClient:
         """Client for the CruiseControl REST API."""
         return CruiseControlClient(
-            username=self.charm.state.balancer.balancer_username,
-            password=self.charm.state.balancer.balancer_password,
+            username=self.charm.state.peer_cluster.balancer_username,
+            password=self.charm.state.peer_cluster.balancer_password,
         )
 
     @property
@@ -160,7 +160,7 @@ class BalancerManager:
 
     def create_internal_topics(self) -> None:
         """Create Cruise Control topics."""
-        bootstrap_servers = self.charm.state.balancer.broker_uris
+        bootstrap_servers = self.charm.state.peer_cluster.broker_uris
         property_file = f'{BALANCER.paths["CONF"]}/cruisecontrol.properties'
 
         for topic in BALANCER_TOPICS:

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -24,6 +24,8 @@ from literals import (
     BALANCER,
     BALANCER_GOALS_TESTING,
     BROKER,
+    CONTROLLER_LISTENER_NAME,
+    CONTROLLER_PORT,
     DEFAULT_BALANCER_GOALS,
     HARD_BALANCER_GOALS,
     INTER_BROKER_USER,
@@ -31,6 +33,7 @@ from literals import (
     JMX_EXPORTER_PORT,
     JVM_MEM_MAX_GB,
     JVM_MEM_MIN_GB,
+    KRAFT_NODE_ID_OFFSET,
     PROFILE_TESTING,
     SECURITY_PROTOCOL_PORTS,
     AuthMap,
@@ -41,7 +44,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_OPTIONS = """
 sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
-authorizer.class.name=kafka.security.authorizer.AclAuthorizer
 allow.everyone.if.no.acl.found=false
 auto.create.topics.enable=false
 """
@@ -273,9 +275,11 @@ class ConfigManager(CommonConfigManager):
     @property
     @override
     def kafka_opts(self) -> str:
-        opts = [
-            f"-Djava.security.auth.login.config={self.workload.paths.zk_jaas}",
-        ]
+        opts = []
+        if not self.state.runs_controller:
+            opts = [
+                f"-Djava.security.auth.login.config={self.workload.paths.zk_jaas}",
+            ]
 
         http_proxy = os.environ.get("JUJU_CHARM_HTTP_PROXY")
         https_proxy = os.environ.get("JUJU_CHARM_HTTPS_PROXY")
@@ -317,6 +321,9 @@ class ConfigManager(CommonConfigManager):
         Returns:
             List of properties to be set
         """
+        if self.state.kraft_mode:
+            return []
+
         return [
             f"broker.id={self.state.unit_broker.unit_id}",
             f"zookeeper.connect={self.state.zookeeper.connect}",
@@ -370,7 +377,7 @@ class ConfigManager(CommonConfigManager):
             f'listener.name.{listener_name}.{listener_mechanism}.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{username}" password="{password}";',
             f"listener.name.{listener_name}.sasl.enabled.mechanisms={self.internal_listener.mechanism}",
         ]
-        for auth in self.client_listeners + self.external_listeners:
+        for auth in self.client_listeners + self.external_listeners + self.extra_listeners:
             if not auth.mechanism.startswith("SCRAM"):
                 continue
 
@@ -568,6 +575,41 @@ class ConfigManager(CommonConfigManager):
         )
 
     @property
+    def authorizer_class(self) -> list[str]:
+        """Return the authorizer Java class used on Kafka."""
+        if self.state.kraft_mode:
+            # return ["authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer"]
+            return []
+        return ["authorizer.class.name=kafka.security.authorizer.AclAuthorizer"]
+
+    @property
+    def controller_properties(self) -> list[str]:
+        """Builds all properties necessary for starting Kafka controller service.
+
+        Returns:
+            List of properties to be set
+        """
+        if self.state.kraft_mode == False:  # noqa: E712
+            return []
+
+        roles = []
+        node_id = self.state.unit_broker.unit_id
+        if self.state.runs_broker:
+            roles.append("broker")
+            node_id += KRAFT_NODE_ID_OFFSET
+        if self.state.runs_controller:
+            roles.append("controller")
+
+        properties = [
+            f"process.roles={','.join(roles)}",
+            f"node.id={node_id}",
+            f"controller.quorum.voters={self.state.peer_cluster.controller_quorum_uris}",
+            f"controller.listener.names={CONTROLLER_LISTENER_NAME}",
+        ]
+
+        return properties
+
+    @property
     def server_properties(self) -> list[str]:
         """Builds all properties necessary for starting Kafka service.
 
@@ -583,6 +625,24 @@ class ConfigManager(CommonConfigManager):
         listeners_repr = [listener.listener for listener in self.all_listeners]
         advertised_listeners = [listener.advertised_listener for listener in self.all_listeners]
 
+        if self.state.kraft_mode:
+            controller_protocol_map = f"{CONTROLLER_LISTENER_NAME}:PLAINTEXT"
+            controller_listener = f"{CONTROLLER_LISTENER_NAME}://0.0.0.0:{CONTROLLER_PORT}"
+
+            # NOTE: Case where the controller is running standalone. Early return with a
+            # smaller subset of config options
+            if not self.state.runs_broker:
+                properties = (
+                    [f"log.dirs={self.state.log_dirs}", f"listeners={controller_listener}"]
+                    + self.controller_properties
+                    # + self.authorizer_class
+                )
+                return properties
+
+            protocol_map.append(controller_protocol_map)
+            if self.state.runs_controller:
+                listeners_repr.append(controller_listener)
+
         properties = (
             [
                 f"super.users={self.state.super_users}",
@@ -594,16 +654,20 @@ class ConfigManager(CommonConfigManager):
                 f"inter.broker.protocol.version={self.inter_broker_protocol_version}",
             ]
             + self.scram_properties
+            + self.auth_properties
             + self.oauth_properties
             + self.config_properties
             + self.default_replication_properties
-            + self.auth_properties
             + self.rack_properties
             + DEFAULT_CONFIG_OPTIONS.split("\n")
+            + self.authorizer_class
+            + self.controller_properties
         )
 
         if self.state.cluster.tls_enabled and self.state.unit_broker.certificate:
-            properties += self.tls_properties + self.zookeeper_tls_properties
+            properties += self.tls_properties
+            if self.state.kraft_mode == False:  # noqa: E712
+                properties += self.zookeeper_tls_properties
 
         if self.state.runs_balancer or BALANCER.value in self.state.peer_cluster.roles:
             properties += KAFKA_CRUISE_CONTROL_OPTIONS.splitlines()
@@ -738,10 +802,12 @@ class BalancerConfigManager(CommonConfigManager):
         if self.config.profile == PROFILE_TESTING:
             goals = BALANCER_GOALS_TESTING
 
-        if self.state.balancer.racks:
+        if self.state.peer_cluster.racks:
             if (
-                min([3, len(self.state.balancer.broker_capacities.get("brokerCapacities", []))])
-                > self.state.balancer.racks
+                min(
+                    [3, len(self.state.peer_cluster.broker_capacities.get("brokerCapacities", []))]
+                )
+                > self.state.peer_cluster.racks
             ):  # replication-factor > racks is not ideal
                 goals = goals + ["RackAwareDistribution"]
             else:
@@ -795,10 +861,10 @@ class BalancerConfigManager(CommonConfigManager):
         """
         properties = (
             [
-                f"bootstrap.servers={self.state.balancer.broker_uris}",
-                f"zookeeper.connect={self.state.balancer.zk_uris}",
+                f"bootstrap.servers={self.state.peer_cluster.broker_uris}",
+                f"zookeeper.connect={self.state.peer_cluster.zk_uris}",
                 "zookeeper.security.enabled=true",
-                f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{self.state.balancer.broker_username}" password="{self.state.balancer.broker_password}";',
+                f'sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{self.state.peer_cluster.broker_username}" password="{self.state.peer_cluster.broker_password}";',
                 f"sasl.mechanism={self.state.default_auth.mechanism}",
                 f"security.protocol={self.state.default_auth.protocol}",
                 f"capacity.config.file={self.workload.paths.capacity_jbod_json}",
@@ -824,8 +890,8 @@ class BalancerConfigManager(CommonConfigManager):
             f"""
             Client {{
                 org.apache.zookeeper.server.auth.DigestLoginModule required
-                username="{self.state.balancer.zk_username}"
-                password="{self.state.balancer.zk_password}";
+                username="{self.state.peer_cluster.zk_username}"
+                password="{self.state.peer_cluster.zk_password}";
             }};
         """
         )
@@ -844,7 +910,7 @@ class BalancerConfigManager(CommonConfigManager):
     def set_broker_capacities(self) -> None:
         """Writes all broker storage capacities to `capacityJBOD.json`."""
         self.workload.write(
-            content=json.dumps(self.state.balancer.broker_capacities),
+            content=json.dumps(self.state.peer_cluster.broker_capacities),
             path=self.workload.paths.capacity_jbod_json,
         )
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -538,7 +538,7 @@ class ConfigManager(CommonConfigManager):
                 Listener(
                     auth_map=auth,
                     scope="EXTERNAL",
-                    host=self.state.unit_broker.host,
+                    host=self.state.unit_broker.node_ip,
                     # default in case service not created yet during cluster init
                     # will resolve during config-changed
                     node_port=node_port,

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -142,7 +142,7 @@ class TLSManager:
         if self.substrate == "vm":
             return {
                 "sans_ip": [
-                    self.state.unit_broker.host,
+                    self.state.unit_broker.internal_address,
                 ],
                 "sans_dns": [self.state.unit_broker.unit.name, socket.getfqdn()]
                 + self._build_extra_sans(),

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -129,14 +129,11 @@ class TLSManager:
 
     def _build_extra_sans(self) -> list[str]:
         """Parse the certificate_extra_sans config option."""
-        extra_sans = self.config.certificate_extra_sans or ""
-        parsed_sans = []
-
-        if extra_sans == "":
-            return parsed_sans
-
-        for sans in extra_sans.split(","):
-            parsed_sans.append(sans.replace("{unit}", str(self.state.unit_broker.unit_id)))
+        extra_sans = self.config.extra_listeners or self.config.certificate_extra_sans or []
+        clean_sans = [san.split(":")[0] for san in extra_sans]
+        parsed_sans = [
+            san.replace("{unit}", str(self.state.unit_broker.unit_id)) for san in clean_sans
+        ]
 
         return parsed_sans
 

--- a/src/workload.py
+++ b/src/workload.py
@@ -114,6 +114,32 @@ class Workload(WorkloadBase):
         command = f"{self.paths.binaries_path}/bin/kafka-{bin_keyword}.sh {' '.join(bin_args)}"
         return self.exec(command=command.split(), env=parsed_opts or None)
 
+    def format_storages(
+        self, uuid: str, internal_user_credentials: dict[str, str] | None = None
+    ) -> None:
+        """Use a passed uuid to format storages."""
+        # NOTE data dirs have changed permissions by storage_attached hook. For some reason
+        # storage command bin needs these locations to be root owned. Momentarily raise permissions
+        # during the format phase.
+        self.exec(["chown", "-R", "root:root", f"{self.paths.data_path}"])
+
+        command = [
+            "format",
+            "--ignore-formatted",
+            "--cluster-id",
+            uuid,
+            "-c",
+            self.paths.server_properties,
+        ]
+        if internal_user_credentials:
+            for user, password in internal_user_credentials.items():
+                command += ["--add-scram", f"SCRAM-SHA-512=[name={user},password={password}]"]
+        self.run_bin_command(bin_keyword="storage", bin_args=command)
+
+        # Drop permissions again for the main process
+        self.exec(["chmod", "-R", "750", f"{self.paths.data_path}"])
+        self.exec(["chown", "-R", f"{USER}:{GROUP}", f"{self.paths.data_path}"])
+
     # ------- Kafka vm specific -------
 
     def install(self) -> None:

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -78,6 +78,7 @@ class TestKRaft:
                     "roles": self.controller_app,
                     "profile": "testing",
                 },
+                resources={"kafka-image": KAFKA_CONTAINER},
                 trust=True,
             )
 

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+import os
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from literals import (
+    CONTROLLER_PORT,
+    PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    PEER_CLUSTER_RELATION,
+    SECURITY_PROTOCOL_PORTS,
+)
+
+from .helpers import (
+    APP_NAME,
+    KAFKA_CONTAINER,
+    get_address,
+    netcat,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.kraft
+
+CONTROLLER_APP = "controller"
+PRODUCER_APP = "producer"
+
+
+class TestKRaft:
+
+    deployment_strat: str = os.environ.get("DEPLOYMENT", "multi")
+    controller_app: str = {"single": APP_NAME, "multi": CONTROLLER_APP}[deployment_strat]
+
+    @pytest.mark.abort_on_fail
+    async def test_build_and_deploy(self, ops_test: OpsTest, kafka_charm):
+        await asyncio.gather(
+            ops_test.model.deploy(
+                kafka_charm,
+                application_name=APP_NAME,
+                num_units=1,
+                series="jammy",
+                config={
+                    "roles": "broker,controller" if self.controller_app == APP_NAME else "broker",
+                    "profile": "testing",
+                },
+                resources={"kafka-image": KAFKA_CONTAINER},
+                trust=True,
+            ),
+            ops_test.model.deploy(
+                "kafka-test-app",
+                application_name=PRODUCER_APP,
+                channel="edge",
+                num_units=1,
+                series="jammy",
+                config={
+                    "topic_name": "HOT-TOPIC",
+                    "num_messages": 100000,
+                    "role": "producer",
+                    "partitions": 20,
+                    "replication_factor": "1",
+                },
+                trust=True,
+            ),
+        )
+
+        if self.controller_app != APP_NAME:
+            await ops_test.model.deploy(
+                kafka_charm,
+                application_name=self.controller_app,
+                num_units=1,
+                series="jammy",
+                config={
+                    "roles": self.controller_app,
+                    "profile": "testing",
+                },
+                trust=True,
+            )
+
+        await ops_test.model.wait_for_idle(
+            apps=list({APP_NAME, self.controller_app}),
+            idle_period=30,
+            timeout=1800,
+            raise_on_error=False,
+        )
+        if self.controller_app != APP_NAME:
+            assert ops_test.model.applications[APP_NAME].status == "blocked"
+            assert ops_test.model.applications[self.controller_app].status == "blocked"
+        else:
+            assert ops_test.model.applications[APP_NAME].status == "active"
+
+    @pytest.mark.abort_on_fail
+    async def test_integrate(self, ops_test: OpsTest):
+        if self.controller_app != APP_NAME:
+            await ops_test.model.add_relation(
+                f"{APP_NAME}:{PEER_CLUSTER_ORCHESTRATOR_RELATION}",
+                f"{CONTROLLER_APP}:{PEER_CLUSTER_RELATION}",
+            )
+
+        await ops_test.model.wait_for_idle(
+            apps=list({APP_NAME, self.controller_app}), idle_period=30
+        )
+
+        async with ops_test.fast_forward(fast_interval="40s"):
+            await asyncio.sleep(120)
+
+        assert ops_test.model.applications[APP_NAME].status == "active"
+        assert ops_test.model.applications[self.controller_app].status == "active"
+
+    @pytest.mark.abort_on_fail
+    async def test_listeners(self, ops_test: OpsTest):
+        print("SLEEPING")
+        logger.info("SLEEPING")
+        await asyncio.sleep(300)
+        address = await get_address(ops_test=ops_test)
+        assert netcat(
+            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].internal
+        )  # Internal listener
+
+        # Client listener should not be enabled if there is no relations
+        assert not netcat(
+            address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
+        )
+
+        # Check controller socket
+        if self.controller_app != APP_NAME:
+            address = await get_address(ops_test=ops_test, app_name=self.controller_app)
+
+        assert netcat(address, CONTROLLER_PORT)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -136,7 +136,7 @@ def test_ready_to_start_blocks_no_zookeeper_relation(ctx: Context, base_state: S
     state_out = ctx.run(ctx.on.start(), state_in)
 
     # Then
-    assert state_out.unit_status == Status.ZK_NOT_RELATED.value.status
+    assert state_out.unit_status == Status.MISSING_MODE.value.status
 
 
 def test_ready_to_start_waits_no_zookeeper_data(ctx: Context, base_state: State) -> None:
@@ -581,7 +581,7 @@ def test_storage_add_disableenables_and_starts(
 
 
 def test_zookeeper_changed_sets_passwords_and_creates_users_with_zk(
-    ctx: Context, base_state: State, zk_data: dict[str, str], passwords_data: dict[str, str]
+    ctx: Context, base_state: State, zk_data: dict[str, str]
 ) -> None:
     """Checks inter-broker passwords are created on zookeeper-changed hook using zk auth."""
     # Given
@@ -795,7 +795,7 @@ def test_config_changed_updates_client_data(ctx: Context, base_state: State) -> 
     patched_update_client_data.assert_called_once()
 
 
-def test_config_changed_restarts(ctx: Context, base_state: State, monkeypatch) -> None:
+def test_config_changed_restarts(ctx: Context, base_state: State) -> None:
     """Checks units rolling-restat on config changed hook."""
     # Given
     cluster_peer = PeerRelation(PEER, PEER)
@@ -841,7 +841,7 @@ def test_on_remove_sysctl_is_deleted(ctx: Context, base_state: State):
     patched_sysctl_remove.assert_called_once()
 
 
-def test_workload_version_is_setted(ctx: Context, base_state: State, monkeypatch):
+def test_workload_version_is_setted(ctx: Context, base_state: State):
     # Given
     output_bin_install = "3.6.0-ubuntu0"
     output_bin_changed = "3.6.1-ubuntu0"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -128,7 +128,7 @@ def test_log_dirs_in_server_properties(ctx: Context, base_state: State) -> None:
 
 
 def test_listeners_in_server_properties(
-    charm_configuration: dict, base_state: State, zk_data: dict[str, str], monkeypatch
+    charm_configuration: dict, base_state: State, zk_data: dict[str, str]
 ) -> None:
     """Checks that listeners are split into INTERNAL, CLIENT and EXTERNAL."""
     # Given

--- a/tests/unit/test_kraft.py
+++ b/tests/unit/test_kraft.py
@@ -91,7 +91,6 @@ def test_ready_to_start_no_peer_cluster(charm_configuration, base_state: State):
 def test_ready_to_start_missing_data_as_controller(charm_configuration, base_state: State):
     # Given
     charm_configuration["options"]["roles"]["default"] = "controller"
-    charm_configuration["options"]["expose-external"]["default"] = "false"
     ctx = Context(
         KafkaCharm,
         meta=METADATA,
@@ -112,7 +111,6 @@ def test_ready_to_start_missing_data_as_controller(charm_configuration, base_sta
 def test_ready_to_start_missing_data_as_broker(charm_configuration, base_state: State):
     # Given
     charm_configuration["options"]["roles"]["default"] = "broker"
-    charm_configuration["options"]["expose-external"]["default"] = "false"
     ctx = Context(
         KafkaCharm,
         meta=METADATA,
@@ -136,7 +134,6 @@ def test_ready_to_start_missing_data_as_broker(charm_configuration, base_state: 
 def test_ready_to_start(charm_configuration, base_state: State):
     # Given
     charm_configuration["options"]["roles"]["default"] = "broker,controller"
-    charm_configuration["options"]["expose-external"]["default"] = "false"
     ctx = Context(
         KafkaCharm,
         meta=METADATA,
@@ -166,4 +163,4 @@ def test_ready_to_start(charm_configuration, base_state: State):
     # Only the internal users should be created.
     assert "admin-password" in next(iter(state_out.secrets)).latest_content
     assert "sync-password" in next(iter(state_out.secrets)).latest_content
-    assert state_out.unit_status == ActiveStatus(), logger.error(f"{state_out.unit_status=}")
+    assert state_out.unit_status == ActiveStatus()

--- a/tests/unit/test_kraft.py
+++ b/tests/unit/test_kraft.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import dataclasses
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from ops import ActiveStatus
+from ops.testing import Container, Context, PeerRelation, Relation, State
+
+from charm import KafkaCharm
+from literals import (
+    CONTAINER,
+    PEER,
+    PEER_CLUSTER_ORCHESTRATOR_RELATION,
+    PEER_CLUSTER_RELATION,
+    SUBSTRATE,
+    Status,
+)
+
+pytestmark = pytest.mark.kraft
+
+logger = logging.getLogger(__name__)
+
+
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+ACTIONS = yaml.safe_load(Path("./actions.yaml").read_text())
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@pytest.fixture()
+def charm_configuration():
+    """Enable direct mutation on configuration dict."""
+    return json.loads(json.dumps(CONFIG))
+
+
+@pytest.fixture()
+def base_state():
+
+    if SUBSTRATE == "k8s":
+        state = State(leader=True, containers=[Container(name=CONTAINER, can_connect=True)])
+
+    else:
+        state = State(leader=True)
+
+    return state
+
+
+def test_ready_to_start_maintenance_no_peer_relation(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    state_in = base_state
+
+    # When
+    state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_PEER_RELATION.value.status
+
+
+def test_ready_to_start_no_peer_cluster(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer])
+
+    # When
+    state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_PEER_CLUSTER_RELATION.value.status
+
+
+def test_ready_to_start_missing_data_as_controller(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "controller"
+    charm_configuration["options"]["expose-external"]["default"] = "false"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    peer_cluster = Relation(PEER_CLUSTER_RELATION, "peer_cluster")
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer, peer_cluster])
+
+    # When
+    state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_BROKER_DATA.value.status
+
+
+def test_ready_to_start_missing_data_as_broker(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "broker"
+    charm_configuration["options"]["expose-external"]["default"] = "false"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    peer_cluster = Relation(
+        PEER_CLUSTER_ORCHESTRATOR_RELATION, "peer_cluster", remote_app_data={"roles": "controller"}
+    )
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer, peer_cluster])
+
+    # When
+    with patch("workload.KafkaWorkload.run_bin_command", return_value="cluster-uuid-number"):
+        state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Then
+    assert state_out.unit_status == Status.NO_QUORUM_URIS.value.status
+
+
+def test_ready_to_start(charm_configuration, base_state: State):
+    # Given
+    charm_configuration["options"]["roles"]["default"] = "broker,controller"
+    charm_configuration["options"]["expose-external"]["default"] = "false"
+    ctx = Context(
+        KafkaCharm,
+        meta=METADATA,
+        config=charm_configuration,
+        actions=ACTIONS,
+    )
+    cluster_peer = PeerRelation(PEER, PEER)
+    state_in = dataclasses.replace(base_state, relations=[cluster_peer])
+
+    # When
+    with (
+        patch(
+            "workload.KafkaWorkload.run_bin_command", return_value="cluster-uuid-number"
+        ) as patched_run_bin_command,
+        patch("health.KafkaHealth.machine_configured", return_value=True),
+        patch("workload.KafkaWorkload.start"),
+        patch("workload.KafkaWorkload.active", return_value=True),
+        patch("charms.operator_libs_linux.v1.snap.SnapCache"),
+    ):
+        state_out = ctx.run(ctx.on.start(), state_in)
+
+    # Then
+    # Second call of format will have to pass "cluster-uuid-number" as set above
+    assert "cluster-uuid-number" in patched_run_bin_command.call_args_list[1][1]["bin_args"]
+    assert "cluster-uuid" in state_out.get_relations(PEER)[0].local_app_data
+    assert "controller-quorum-uris" in state_out.get_relations(PEER)[0].local_app_data
+    # Only the internal users should be created.
+    assert "admin-password" in next(iter(state_out.secrets)).latest_content
+    assert "sync-password" in next(iter(state_out.secrets)).latest_content
+    assert state_out.unit_status == ActiveStatus(), logger.error(f"{state_out.unit_status=}")

--- a/tests/unit/test_structured_config.py
+++ b/tests/unit/test_structured_config.py
@@ -174,3 +174,14 @@ def test_incorrect_roles():
     valid_values = ["broker", "balancer", "balancer,broker", "broker, balancer "]
     check_invalid_values("roles", erroneus_values)
     check_valid_values("roles", valid_values)
+
+
+def test_incorrect_extra_listeners():
+    erroneus_values = [
+        "missing.port",
+        "low.port:15000",
+        "high.port:60000",
+        "non.unique:30000,other.non.unique:30000",
+        "close.port:30000,other.close.port:30001",
+    ]
+    check_invalid_values("extra_listeners", erroneus_values)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -94,18 +94,31 @@ def test_mtls_added(ctx: Context, base_state: State) -> None:
 
 
 @pytest.mark.parametrize(
-    ["extra_sans", "expected"],
+    ["config_option", "extra_sans", "expected"],
     [
-        ("", []),
-        ("worker{unit}.com", ["worker0.com"]),
-        ("worker{unit}.com,{unit}.example", ["worker0.com", "0.example"]),
+        ("certificate_extra_sans", "", []),
+        ("certificate_extra_sans", "worker{unit}.com", ["worker0.com"]),
+        (
+            "certificate_extra_sans",
+            "worker{unit}.com,{unit}.example",
+            ["worker0.com", "0.example"],
+        ),
+        (
+            "extra_listeners",
+            "worker{unit}.com:30000,{unit}.example:40000,nonunit.domain.com:45000",
+            ["worker0.com", "0.example", "nonunit.domain.com"],
+        ),
     ],
 )
 def test_extra_sans_config(
-    charm_configuration: dict, base_state: State, extra_sans: str, expected: list[str]
+    charm_configuration: dict,
+    base_state: State,
+    config_option: str,
+    extra_sans: str,
+    expected: list[str],
 ) -> None:
     # Given
-    charm_configuration["options"]["certificate_extra_sans"]["default"] = extra_sans
+    charm_configuration["options"][config_option]["default"] = extra_sans
     cluster_peer = PeerRelation(
         PEER,
         PEER,

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,9 @@ set_env =
     ha: TEST_FILE=ha/test_ha.py
     balancer-single: DEPLOYMENT=single
     balancer-multi: DEPLOYMENT=multi
+    kraft-single: DEPLOYMENT=single
+    kraft-multi: DEPLOYMENT=multi
+
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR
@@ -82,6 +85,18 @@ commands =
     poetry run coverage report
     poetry run coverage xml
 
+
+[testenv:integration]
+description = Run integration tests
+pass_env =
+    {[testenv]pass_env}
+    CI
+    CI_PACKED_CHARMS
+commands =
+    poetry install --no-root --with integration
+    poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/
+
+
 [testenv:integration-{charm,provider,scaling,password-rotation,tls,upgrade,ha}]
 description = Run integration tests
 pass_env =
@@ -99,3 +114,16 @@ pass_env =
 commands =
     poetry install --no-root --with integration
     poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_balancer.py
+
+[testenv:integration-kraft-{single,multi}]
+description = Run KRaft mode tests
+set_env =
+    {[testenv]set_env}
+    # Workaround for https://github.com/python-poetry/poetry/issues/6958
+    POETRY_INSTALLER_PARALLEL = false
+pass_env =
+    {[testenv]pass_env}
+    CI
+commands =
+    poetry install --no-root --with integration
+    poetry run pytest -vv --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_kraft.py


### PR DESCRIPTION
## Features
#### `feat(DPE-5114): add kraft support`
- Features are as found in the VM charm at point of writing
- This also required `refactor: remove broker.host, use internal_address/node_ip`, as `broker.host` was erroneously resolving to the nodeip for the unit when configuring `controller.quorum.listeners`, which Kafka can't bind to
#### `feat(DPE-5757): add extra_listeners`
#### `feat: support prefixed topic-names`

## Refactor + Tweaks
#### `chore(DPE-5544): remove lost+found for both vm+k8s`
- Before, this was a K8s only feature, minor tweaks to make compatible with VMs also
#### `ci: tweak retries for ci stabilisation`