### PR TITLE
 [DPE-6547] fix: KRaft multi-mode scaling bug on broker side

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -200,12 +200,7 @@ class PeerCluster(RelationState):
         if not self.relation or not self.relation.app:
             return ""
 
-        return self.data_interface._fetch_relation_data_with_secrets(
-            component=self.relation.app,
-            req_secret_fields=["controller-password"],
-            relation=self.relation,
-            fields=["controller-password"],
-        ).get("controller-password", "")
+        return self._fetch_from_secrets("controller", "controller-password")
 
     @property
     def cluster_uuid(self) -> str:

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -40,9 +40,7 @@ class TestKRaft:
     deployment_strat: str = os.environ.get("DEPLOYMENT", "multi")
     controller_app: str = {"single": APP_NAME, "multi": CONTROLLER_APP}[deployment_strat]
 
-    async def _assert_broker_listeners_accessible(
-        self, ops_test: OpsTest, broker_unit_num=0
-    ):
+    async def _assert_broker_listeners_accessible(self, ops_test: OpsTest, broker_unit_num=0):
         logger.info(f"Asserting broker listeners are up: {APP_NAME}/{broker_unit_num}")
         address = await get_address(ops_test=ops_test, app_name=APP_NAME, unit_num=broker_unit_num)
         assert netcat(
@@ -198,10 +196,8 @@ class TestKRaft:
                 assert status == KRaftUnitStatus.OBSERVER
 
         for unit_num in range(3):
-            await self._assert_broker_listeners_accessible(
-                ops_test, broker_unit_num=unit_num
-            )
-        
+            await self._assert_broker_listeners_accessible(ops_test, broker_unit_num=unit_num)
+
         for unit_num in range(5):
             await self._assert_controller_listeners_accessible(
                 ops_test, controller_unit_num=unit_num
@@ -231,9 +227,5 @@ class TestKRaft:
         assert KRaftUnitStatus.LEADER in unit_status.values()
 
         for unit_num in range(3):
-            await self._assert_broker_listeners_accessible(
-                ops_test, broker_unit_num=unit_num
-            )
-        await self._assert_controller_listeners_accessible(
-            ops_test, controller_unit_num=unit_num
-        )            
+            await self._assert_broker_listeners_accessible(ops_test, broker_unit_num=unit_num)
+        await self._assert_controller_listeners_accessible(ops_test, controller_unit_num=unit_num)

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -40,9 +40,10 @@ class TestKRaft:
     deployment_strat: str = os.environ.get("DEPLOYMENT", "multi")
     controller_app: str = {"single": APP_NAME, "multi": CONTROLLER_APP}[deployment_strat]
 
-    async def _assert_listeners_accessible(
-        self, ops_test: OpsTest, broker_unit_num=0, controller_unit_num=0
+    async def _assert_broker_listeners_accessible(
+        self, ops_test: OpsTest, broker_unit_num=0
     ):
+        logger.info(f"Asserting broker listeners are up: {APP_NAME}/{broker_unit_num}")
         address = await get_address(ops_test=ops_test, app_name=APP_NAME, unit_num=broker_unit_num)
         assert netcat(
             address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].internal
@@ -53,7 +54,13 @@ class TestKRaft:
             address, SECURITY_PROTOCOL_PORTS["SASL_PLAINTEXT", "SCRAM-SHA-512"].client
         )
 
+    async def _assert_controller_listeners_accessible(
+        self, ops_test: OpsTest, controller_unit_num=0
+    ):
         # Check controller socket
+        logger.info(
+            f"Asserting controller listeners are up: {self.controller_app}/{controller_unit_num}"
+        )
         if self.controller_app != APP_NAME:
             address = await get_address(
                 ops_test=ops_test, app_name=self.controller_app, unit_num=controller_unit_num
@@ -148,7 +155,8 @@ class TestKRaft:
         print("SLEEPING")
         logger.info("SLEEPING")
         await asyncio.sleep(300)
-        await self._assert_listeners_accessible(ops_test)
+        await self._assert_broker_listeners_accessible(ops_test)
+        await self._assert_controller_listeners_accessible(ops_test)
 
     @pytest.mark.abort_on_fail
     async def test_authorizer(self, ops_test: OpsTest):
@@ -161,6 +169,10 @@ class TestKRaft:
     @pytest.mark.abort_on_fail
     async def test_scale_out(self, ops_test: OpsTest):
         await ops_test.model.applications[self.controller_app].add_units(count=4)
+
+        if self.deployment_strat == "multi":
+            await ops_test.model.applications[APP_NAME].add_units(count=2)
+
         await ops_test.model.wait_for_idle(
             apps=list({APP_NAME, self.controller_app}),
             status="active",
@@ -185,6 +197,16 @@ class TestKRaft:
             else:
                 assert status == KRaftUnitStatus.OBSERVER
 
+        for unit_num in range(3):
+            await self._assert_broker_listeners_accessible(
+                ops_test, broker_unit_num=unit_num
+            )
+        
+        for unit_num in range(5):
+            await self._assert_controller_listeners_accessible(
+                ops_test, controller_unit_num=unit_num
+            )
+
     @pytest.mark.abort_on_fail
     async def test_scale_in(self, ops_test: OpsTest):
         await ops_test.model.applications[self.controller_app].scale(scale=3)
@@ -207,4 +229,11 @@ class TestKRaft:
         )
 
         assert KRaftUnitStatus.LEADER in unit_status.values()
-        await self._assert_listeners_accessible(ops_test, broker_unit_num=0, controller_unit_num=0)
+
+        for unit_num in range(3):
+            await self._assert_broker_listeners_accessible(
+                ops_test, broker_unit_num=unit_num
+            )
+        await self._assert_controller_listeners_accessible(
+            ops_test, controller_unit_num=unit_num
+        )            

--- a/tests/integration/test_kraft.py
+++ b/tests/integration/test_kraft.py
@@ -59,10 +59,9 @@ class TestKRaft:
         logger.info(
             f"Asserting controller listeners are up: {self.controller_app}/{controller_unit_num}"
         )
-        if self.controller_app != APP_NAME:
-            address = await get_address(
-                ops_test=ops_test, app_name=self.controller_app, unit_num=controller_unit_num
-            )
+        address = await get_address(
+            ops_test=ops_test, app_name=self.controller_app, unit_num=controller_unit_num
+        )
 
         assert netcat(address, CONTROLLER_PORT)
 
@@ -228,4 +227,6 @@ class TestKRaft:
 
         for unit_num in range(3):
             await self._assert_broker_listeners_accessible(ops_test, broker_unit_num=unit_num)
-        await self._assert_controller_listeners_accessible(ops_test, controller_unit_num=unit_num)
+            await self._assert_controller_listeners_accessible(
+                ops_test, controller_unit_num=unit_num
+            )


### PR DESCRIPTION
This PR fixes a `RelationDataAccessError` bug occurred in KRaft multi-mode on broker side during scale-out. 

## Bugfixes:
-  KRaft multi-mode, broker-side scale-out results in error state.