### PR TITLE
[DPE-7284] feat: add support for secret-based user management

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,19 +1,5 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-set-password:
-  description: Change an internal system user's password.
-    It is for internal charm users and SHOULD NOT be used by applications.
-    This action must be called on the leader unit.
-  params:
-    username:
-      type: string
-      description: The internal username to set password for.
-      enum: [admin, sync]
-    password:
-      type: string
-      description: The password will be auto-generated if this option is not specified.
-  required: [username]
-
 pre-upgrade-check:
   description: Run necessary pre-upgrade checks before executing a charm upgrade.
 
@@ -30,11 +16,6 @@ set-tls-private-key:
       description: The content of private key for internal communications with clients.
         Content will be auto-generated if this option is not specified.
         Can be raw-string, or base64 encoded.
-
-get-admin-credentials:
-  description: Get administrator authentication credentials for client commands
-    The returned client_properties can be used for Apache Kafka bin commands using `--bootstrap-server` and `--command-config` for admin level administration
-    This action must be called on the leader unit.
 
 get-listeners:
   description: Get all active listeners and their port allocations

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,13 @@ options:
       This configuration accepts the following roles: 'broker' (standard functionality), 'balancer' (cruise control), 'controller' (KRaft mode).
     type: string
     default: broker
+  system-users:
+    description: |
+      User-provided secret ID which defines internal username/passwords on the Apache Kafka cluster.
+      The secret ID format is like "secret:cvh7kruupa1s46bqvuig" and should not be confused with secret name or label.
+      The secret could be defined using `juju add-secret <secret-name> <user>=<admin-password>` command, where `<user>` is one of the internal users defined by the charm: `sync` or `admin`.
+      The `juju add-secret` command will output the secret ID, which can then be granted to the charm and configured using `juju config` command.
+    type: string
   compression_type:
     description: Specify the final compression type for a given topic. This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4', 'zstd'). It additionally accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the original compression codec set by the producer.
     type: string

--- a/src/events/actions.py
+++ b/src/events/actions.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING
 from ops.charm import ActionEvent
 from ops.framework import Object
 
-from literals import ADMIN_USER, INTERNAL_USERS
-
 if TYPE_CHECKING:
     from charm import KafkaCharm
     from events.broker import BrokerOperator
@@ -27,13 +25,6 @@ class ActionEvents(Object):
         self.dependent = dependent
         self.charm: "KafkaCharm" = dependent.charm
 
-        self.framework.observe(
-            getattr(self.charm.on, "set_password_action"), self._set_password_action
-        )
-        self.framework.observe(
-            getattr(self.charm.on, "get_admin_credentials_action"),
-            self._get_admin_credentials_action,
-        )
         self.framework.observe(
             getattr(self.charm.on, "get_listeners_action"), self._get_listeners_action
         )
@@ -59,73 +50,3 @@ class ActionEvents(Object):
             )
 
         event.set_results(result)
-
-    def _set_password_action(self, event: ActionEvent) -> None:
-        """Handler for set-password action.
-
-        Set the password for a specific user, if no passwords are passed, generate them.
-        """
-        if not self.model.unit.is_leader():
-            msg = "Password rotation must be called on leader unit"
-            logger.error(msg)
-            event.fail(msg)
-            return
-
-        if not self.dependent.upgrade.idle:
-            msg = f"Cannot set password while upgrading (upgrade_stack: {self.dependent.upgrade.upgrade_stack})"
-            logger.error(msg)
-            event.fail(msg)
-            return
-
-        if not self.dependent.healthy:
-            msg = "Unit is not healthy"
-            logger.error(msg)
-            event.fail(msg)
-            return
-
-        username = event.params["username"]
-        if username not in INTERNAL_USERS:
-            msg = f"Can only update internal charm users: {INTERNAL_USERS}, not {username}."
-            logger.error(msg)
-            event.fail(msg)
-            return
-
-        new_password = event.params.get("password", self.dependent.workload.generate_password())
-
-        if new_password in self.charm.state.cluster.internal_user_credentials.values():
-            msg = "Password already exists, please choose a different password."
-            logger.error(msg)
-            event.fail(msg)
-            return
-
-        try:
-            self.dependent.auth_manager.add_user(username=username, password=new_password)
-        except Exception as e:
-            logger.error(str(e))
-            event.fail(f"unable to set password for {username}")
-            return
-
-        # Store the password on application databag
-        self.charm.state.cluster.relation_data.update({f"{username}-password": new_password})
-        event.set_results({f"{username}-password": new_password})
-
-    def _get_admin_credentials_action(self, event: ActionEvent) -> None:
-        client_properties = self.charm.workload.read(self.charm.workload.paths.client_properties)
-
-        if not client_properties:
-            msg = "client.properties file not found on target unit."
-            logger.error(msg)
-            event.fail(msg)
-            return
-
-        admin_properties = set(client_properties) - set(
-            self.dependent.config_manager.tls_properties
-        )
-
-        event.set_results(
-            {
-                "username": ADMIN_USER,
-                "password": self.charm.state.cluster.internal_user_credentials[ADMIN_USER],
-                "client-properties": "\n".join(admin_properties),
-            }
-        )

--- a/src/events/broker.py
+++ b/src/events/broker.py
@@ -28,6 +28,7 @@ from events.controller import KRaftHandler
 from events.oauth import OAuthHandler
 from events.provider import KafkaProvider
 from events.upgrade import KafkaDependencyModel, KafkaUpgrade
+from events.user_secrets import SecretsHandler
 from health import KafkaHealth
 from literals import (
     BROKER,
@@ -91,6 +92,7 @@ class BrokerOperator(Object):
         self.provider = KafkaProvider(self)
         self.oauth = OAuthHandler(self)
         self.kraft = KRaftHandler(self)
+        self.user_secrets = SecretsHandler(self)
 
         # MANAGERS
 

--- a/src/events/user_secrets.py
+++ b/src/events/user_secrets.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Event Handler for user-defined secret events.
+
+Internal user management could be done by defining secrets
+and granting their access to the charm.
+
+The flow for defining secrets and granting access to the charm would be as below:
+
+    juju add-secret my-auth admin=goodpass
+    # secret:cvh7kruupa1s46bqvuig
+    juju grant-secret my-auth kafka
+    juju config kafka system-users=secret:cvh7kruupa1s46bqvuig
+
+And the update flow would be as simple as:
+
+    juju update-secret my-auth admin=Str0ng_pass
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops import ModelError, SecretNotFoundError
+from ops.charm import (
+    SecretChangedEvent,
+)
+from ops.framework import Object
+
+from literals import INTERNAL_USERS
+
+if TYPE_CHECKING:
+    from charm import KafkaCharm
+    from events.broker import BrokerOperator
+
+
+logger = logging.getLogger(__name__)
+
+
+class SecretsHandler(Object):
+    """Handler for events related to user-defined secrets."""
+
+    def __init__(self, dependent: "BrokerOperator") -> None:
+        super().__init__(dependent.charm, "connect-secrets")
+        self.dependent = dependent
+        self.charm: "KafkaCharm" = dependent.charm
+        self.state = self.charm.state
+        self.workload = self.charm.workload
+
+        self.framework.observe(getattr(self.charm.on, "config_changed"), self._on_secret_changed)
+        self.framework.observe(getattr(self.charm.on, "secret_changed"), self._on_secret_changed)
+
+    def _on_secret_changed(self, event: SecretChangedEvent) -> None:
+        """Handle the `secret_changed` event."""
+        if not self.model.unit.is_leader():
+            return
+
+        if not all(
+            [
+                self.dependent.upgrade.idle,
+                self.dependent.healthy,
+                self.workload.container_can_connect,
+            ]
+        ):
+            event.defer()
+            return
+
+        credentials = self.load_auth_secret()
+        saved_state = self.state.cluster.internal_user_credentials
+        changed = {u for u in credentials if credentials[u] != saved_state.get(u)}
+
+        if not changed:
+            return
+
+        logger.info(f"Credentials change detected for {changed}")
+
+        # Store the password on application databag
+        for username in changed:
+            new_password = credentials[username]
+            self.state.cluster.relation_data.update({f"{username}-password": new_password})
+
+        try:
+            for username in changed:
+                self.dependent.auth_manager.add_user(
+                    username=username, password=credentials[username]
+                )
+        except Exception as e:
+            logger.error(f"unable to set password for {username}: {e}")
+            return
+
+        # This will update peer-cluster data
+        self.charm.on.config_changed.emit()
+
+    def load_auth_secret(self) -> dict[str, str]:
+        """Loads user-defined credentials from the secrets."""
+        if not (secret_id := self.charm.config.system_users):
+            return {}
+
+        try:
+            secret_content = self.model.get_secret(id=secret_id).get_content(refresh=True)
+        except (SecretNotFoundError, ModelError) as e:
+            logging.error(f"Failed to fetch the secret, details: {e}")
+            return {}
+
+        creds = {
+            username: password
+            for username, password in secret_content.items()
+            if username in INTERNAL_USERS
+        }
+
+        denied_users = set(secret_content) - set(creds)
+
+        if denied_users:
+            logger.error(f"Can't set password for non-internal user(s) {', '.join(denied_users)}")
+
+        return creds

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -85,6 +85,7 @@ SERVER_PROPERTIES_BLACKLIST = [
     "extra_listeners",
     "roles",
     "expose_external",
+    "system_users",
 ]
 
 

--- a/tests/unit/test_user_secrets.py
+++ b/tests/unit/test_user_secrets.py
@@ -1,0 +1,136 @@
+import dataclasses
+import logging
+from pathlib import Path
+from typing import cast
+from unittest.mock import PropertyMock, patch
+
+import pytest
+import yaml
+from ops.testing import Container, Context, PeerRelation, Secret, State
+from src.charm import KafkaCharm
+from src.literals import CONTAINER, INTERNAL_USERS, PEER, SUBSTRATE
+
+logger = logging.getLogger(__name__)
+AUTH_CONFIG_KEY = "system-users"
+CONFIG = yaml.safe_load(Path("./config.yaml").read_text())
+ACTIONS = yaml.safe_load(Path("./actions.yaml").read_text())
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+
+@pytest.fixture()
+def base_state(kraft_data: dict[str, str], passwords_data: dict[str, str]):
+    config = {"roles": "broker,controller"}
+    peer_rel = PeerRelation(PEER, PEER, local_app_data=kraft_data | passwords_data)
+
+    if SUBSTRATE == "k8s":
+        state = State(
+            leader=True,
+            containers=[Container(name=CONTAINER, can_connect=True)],
+            config=config,
+            relations=[peer_rel],
+        )
+
+    else:
+        state = State(leader=True, config=config, relations=[peer_rel])
+
+    return state
+
+
+@pytest.fixture()
+def ctx() -> Context:
+    ctx = Context(KafkaCharm, meta=METADATA, config=CONFIG, actions=ACTIONS, unit_id=0)
+    return ctx
+
+
+@pytest.mark.parametrize("secret_provided", [True, False])
+@pytest.mark.parametrize("user", INTERNAL_USERS + ["foo", "relation-7"])
+def test_set_credentials(
+    ctx: Context,
+    base_state: State,
+    secret_provided: bool,
+    user: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tests setting username/passwords through secrets."""
+    caplog.set_level(logging.ERROR)
+    auth_secret = Secret(
+        label="auth_secret",
+        tracked_content={user: "newpass"},
+    )
+    state_in = dataclasses.replace(
+        base_state,
+        secrets=[auth_secret],
+        config=base_state.config | ({AUTH_CONFIG_KEY: auth_secret.id} if secret_provided else {}),
+    )
+
+    with (
+        ctx(ctx.on.secret_changed(auth_secret), state_in) as mgr,
+        patch(
+            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock(return_value=True)
+        ),
+    ):
+        charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
+        previous_password = charm.state.cluster.internal_user_credentials.get(user)
+        _ = mgr.run()
+
+    if secret_provided and user not in INTERNAL_USERS:
+        log_record = caplog.records[-1]
+        assert "can't set password for non-internal user(s)" in log_record.msg.lower()
+        assert log_record.levelname == "ERROR"
+        return
+
+    assert previous_password != "newpass"
+    new_password = charm.state.cluster.internal_user_credentials.get(user)
+
+    if secret_provided:
+        assert new_password != previous_password
+        assert new_password == "newpass"
+    else:
+        assert new_password == previous_password
+
+
+def test_secret_removed_preserves_credentials(
+    ctx: Context,
+    base_state: State,
+) -> None:
+    """Tests removing users through secrets."""
+    auth_secret = Secret(
+        label="auth_secret",
+        tracked_content={"admin": "newpass"},
+    )
+    state_in = dataclasses.replace(
+        base_state,
+        secrets=[auth_secret],
+        config=base_state.config | {AUTH_CONFIG_KEY: auth_secret.id},
+    )
+
+    with (
+        ctx(ctx.on.secret_changed(auth_secret), state_in) as mgr,
+        patch(
+            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock(return_value=True)
+        ),
+    ):
+        charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
+        previous_password = charm.state.cluster.internal_user_credentials.get("admin")
+        _ = mgr.run()
+
+    state_interim = dataclasses.replace(
+        state_in,
+        config=base_state.config,
+    )
+
+    with (
+        ctx(ctx.on.config_changed(), state_interim) as mgr,
+        patch(
+            "events.broker.BrokerOperator.healthy", new_callable=PropertyMock(return_value=True)
+        ),
+    ):
+        charm: KafkaCharm = cast(KafkaCharm, mgr.charm)
+        new_password = charm.state.cluster.internal_user_credentials.get("admin")
+        _ = mgr.run()
+
+    # since no secret is defined, we expect only admin user to remain
+    assert previous_password == new_password
+    assert len(charm.state.cluster.internal_user_credentials) == 2
+    for user in INTERNAL_USERS:
+        assert charm.state.cluster.internal_user_credentials[user]


### PR DESCRIPTION
This PR adds support for secret-based user management, compliant to DA146, and removes get/set-password actions.

## Changes:
- Adds `system-users` config option
- Adds `user_secrets` event handler
- Removes `set-password` and `get-user-credentials` actions