### PR TITLE
Update Charmhub docs link

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,7 +9,7 @@ description: |
   Apache Kafka is a free, open source software project by the Apache Software Foundation. 
   Users can find out more at the [Apache Kafka project page](https://kafka.apache.org/).
 summary: Charmed Apache Kafka K8s Operator
-docs: https://discourse.charmhub.io/t/charmed-kafka-k8s-documentation/10296
+docs: https://discourse.charmhub.io/t/charmed-apache-kafka-k8s/18330
 source: https://github.com/canonical/kafka-k8s-operator
 issues: https://github.com/canonical/kafka-k8s-operator/issues
 website:


### PR DESCRIPTION
Update the link for the documentation in metadata.yaml to replace the dull set of documentation with a Charmhub's Description tab content.