### PR TITLE
docs: Hotifx for docs 404 page rendering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,7 +170,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'charmed-kafka-k8s'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/


### PR DESCRIPTION
Uncommented and populated the slug parameter in docs config to fix the 404 page rendering on documentation.ubuntu.com