### PR TITLE
Implement page-to-page Discourse redirects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -214,8 +214,9 @@ html_static_path = ["_static"]
 # NOTE: If undefined, set to None, or empty,
 #       the sphinx_reredirects extension will be disabled.
 
-redirects = {}
+# redirects = {}
 
+rediraffe_redirects = "redirects.txt"
 
 ###########################
 # Link checker exceptions #
@@ -288,6 +289,7 @@ extensions = [
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
+    "sphinxext.rediraffe",
 ]
 
 # Excludes files or directories from processing

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -25,7 +25,7 @@ main supported cloud platforms.
 ### Juju
 
 Juju is the component responsible for orchestrating the entire lifecycle, from deployment to Day 2 operations. For more information on Juju security hardening, see the
-[Juju security page](https://documentation.ubuntu.com/juju/3.6/explanation/juju-security/) and the [How to harden your deployment](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/#harden-your-deployment) guide.
+[Juju security page](https://documentation.ubuntu.com/juju/3.6/explanation/juju-security/) and the [How to harden your deployment](https://documentation.ubuntu.com/juju/latest/howto/manage-your-juju-deployment/harden-your-juju-deployment/) guide.
 
 #### Cloud credentials
 

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,70 @@
+# The redirects.txt file stores all the redirects for the published docs
+# If you change a filename, move or delete a file, you need a redirect here.
+# - Comment lines start with a hash (#) and are ignored
+# - Each redirect should appear on its own line
+
+# We are using the dirhtml builder, so files are treated as directories:
+# - A file is built like `filename/index.html`, not `filename.html`
+# - *Do* include a trailing slash at the end of the path
+# - *Do not* include a file extension or you'll get errors
+# - Paths don't need a slash in front of them
+
+# Example:
+# redirect/from/file/ redirect/to/file/
+
+# Tutorial
+
+t-overview/ tutorial/
+t-setup-environment/ tutorial/environment/
+t-deploy/ tutorial/deploy/
+t-relate-kafka/ tutorial/integrate-with-client-applications/
+t-manage-passwords/ tutorial/manage-passwords/
+t-enable-encryption/ tutorial/enable-encryption/
+t-reassign-partitions/ tutorial/rebalance-partitions/
+t-cleanup-environment/ tutorial/cleanup/
+
+# How-to guides
+
+h-deploy/ how-to/deploy/
+h-deploy-anywhere/ how-to/deploy/
+h-deploy-eks/ how-to/deploy/deploy-eks/
+h-deploy-aks/ how-to/deploy/deploy-aks/
+
+h-manage-units/ how-to/manage-units/
+h-manage-app/ how-to/manage-applications/
+h-enable-encryption/ how-to/enable-encryption/
+h-upgrade/ how-to/upgrade/
+
+h-monitoring/ how-to/monitoring/
+h-enable-monitoring/ how-to/monitoring/
+h-integrate-alerts-dashboards/ how-to/monitoring/
+
+# h-cluster/ how-to/cluster/
+h-cluster-migration/ how-to/migrate/
+# h-cluster-replication/ how-to/cluster/replication/
+
+h-external-k8s-connection/ how-to/external-k8s-connection/
+h-backup/ how-to/back-up-and-restore/
+h-manage-message-schemas/ how-to/schemas/
+
+# Reference
+
+r-releases/ reference/release-notes/
+r-rev56_51/ reference/release-notes/revision-56-51/
+r-rev82/ reference/release-notes/revision-82/
+
+# r-actions/ https://charmhub.io/kafka-k8s/actions?channel=3/edge
+# r-configurations/ https://charmhub.io/kafka-k8s/configure?channel=3/edge
+# r-libraries/ https://charmhub.io/kafka-k8s/libraries/kafka?channel=3/edge
+r-file-system-paths/ reference/file-system-paths/
+r-listeners/ reference/listeners/
+r-statuses/ reference/statuses/
+r-requirements/ reference/requirements/
+r-contacts/ reference/contact/
+
+# Explanation
+
+e-security/ explanation/security/
+e-cryptography/ explanation/cryptography/
+e-cluster-configuration/ explanation/cluster-configuration/
+e-trademarks/ explanation/trademarks/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ packaging
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinxext-rediraffe


### PR DESCRIPTION
Implementing page-to-page matching to apply after wildcard redirects.
You can check them by navigating to the preview build URLs:

Test 1:
https://canonical-ubuntu-documentation-library--213.com.readthedocs.build/charmed-kafka-k8s/213/t-relate-kafka/
should redirect to
https://canonical-ubuntu-documentation-library--213.com.readthedocs.build/charmed-kafka-k8s/213/tutorial/integrate-with-client-applications/index.html

Test 2:
https://canonical-ubuntu-documentation-library--213.com.readthedocs.build/charmed-kafka-k8s/213/h-deploy-aks/
should redirect to
https://canonical-ubuntu-documentation-library--213.com.readthedocs.build/charmed-kafka-k8s/213/how-to/deploy/deploy-aks/index.html