### PR TITLE
[DPE-7583] Split metadata.log.dir from log.dirs

### DIFF
--- a/src/core/cluster.py
+++ b/src/core/cluster.py
@@ -425,7 +425,18 @@ class ClusterState(Object):
         Returns:
             String of log.dirs property value to be set
         """
-        return ",".join([os.fspath(storage.location) for storage in self.model.storages["data"]])
+        return ",".join(
+            [os.fspath(storage.location / "log") for storage in self.model.storages["data"]]
+        )
+
+    @property
+    def metadata_log_dir(self) -> str:
+        """Builds the necessary metadata.log.dir based on log_dirs.
+
+        Returns:
+            String of metadata.log.dir property value to be set
+        """
+        return f"{self.log_dirs.split(',')[0].rstrip('/log')}/metadata"
 
     @property
     def planned_units(self) -> int:

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -763,6 +763,7 @@ class ConfigManager(CommonConfigManager):
                 [
                     f"super.users={self.state.super_users}",
                     f"log.dirs={self.state.log_dirs}",
+                    f"metadata.log.dir={self.state.metadata_log_dir}",
                     f"listeners={','.join(controller_listeners)}",
                     f"listener.security.protocol.map={','.join(controller_protocol_map)}",
                 ]
@@ -781,6 +782,7 @@ class ConfigManager(CommonConfigManager):
             [
                 f"super.users={self.state.super_users}",
                 f"log.dirs={self.state.log_dirs}",
+                f"metadata.log.dir={self.state.metadata_log_dir}",
                 f"listener.security.protocol.map={','.join(protocol_map)}",
                 f"listeners={','.join(listeners_repr)}",
                 f"advertised.listeners={','.join(advertised_listeners)}",

--- a/src/managers/controller.py
+++ b/src/managers/controller.py
@@ -84,11 +84,7 @@ class ControllerManager:
         return uuid
 
     def get_metadata_directory_id(self, log_dirs: str) -> str:
-        """Read directory.id from meta.properties file in the logs dir.
-
-        If metadata.log.dir is not set, it will be found in the first log directory declared in
-        log.dirs
-        """
+        """Read directory.id from meta.properties file in the metadata logs dir."""
         raw = self.workload.read(os.path.join(log_dirs, "meta.properties"))
         for line in raw:
             if line.startswith("directory.id"):
@@ -124,7 +120,7 @@ class ControllerManager:
             if "DuplicateVoterException" not in error_details:
                 raise e
 
-        metadata_directory_id = self.get_metadata_directory_id(self.state.log_dirs)
+        metadata_directory_id = self.get_metadata_directory_id(self.state.metadata_log_dir)
         return metadata_directory_id
 
     @retry(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -126,6 +126,23 @@ def test_log_dirs_in_server_properties(ctx: Context, base_state: State) -> None:
     assert found_log_dirs
 
 
+def test_metadata_log_dir_in_server_properties(ctx: Context, base_state: State) -> None:
+    """Checks that metadata.log.dir is added to server_properties."""
+    # Given
+    found_metadata_log_dir = False
+    state_in = base_state
+
+    # When
+    with (ctx(ctx.on.config_changed(), state_in) as manager,):
+        charm = cast(KafkaCharm, manager.charm)
+        for prop in charm.broker.config_manager.server_properties:
+            if "metadata.log.dir" in prop:
+                found_metadata_log_dir = True
+
+    # Then
+    assert found_metadata_log_dir
+
+
 def test_listeners_in_server_properties(charm_configuration: dict, base_state: State) -> None:
     """Checks that listeners are split into INTERNAL, CLIENT and EXTERNAL."""
     # Given


### PR DESCRIPTION
Syncs [vm](https://github.com/canonical/kafka-operator/pull/365)

Splits metatada into a separate subfolder.
- log.dirs now are located on a `log` folder.
- metadata.log.dir is located on a `metadata` folder.