### PR TITLE
[DPE-8464] fix: Workload last_restart parse bug for inactive services

### DIFF
--- a/src/workload.py
+++ b/src/workload.py
@@ -68,7 +68,10 @@ class Workload(WorkloadBase):
 
         # Convert datetime strings to pythonic objects
         for item in output:
-            item["Since"] = datetime.datetime.fromisoformat(item["Since"])
+            try:
+                item["Since"] = datetime.datetime.fromisoformat(item["Since"])
+            except ValueError:
+                item["Since"] = datetime.datetime.min
 
         # Changes are ordered ASC by time, so reverse the list
         service = [

--- a/tests/unit/test_workload.py
+++ b/tests/unit/test_workload.py
@@ -42,6 +42,18 @@ def test_last_restart_parses_correctly(patched_exec, monkeypatch):
         == datetime.datetime(2025, 8, 8, 8, 22, 37, tzinfo=datetime.timezone.utc).timestamp()
     )
 
+    patched_exec.return_value = inspect.cleandoc(
+        """
+    Service   Startup   Current   Since
+    kafka     enabled   active    2025-08-15T11:05:51Z
+    promtail  disabled  inactive  -"""
+    )
+
+    assert (
+        KafkaWorkload(MagicMock()).last_restart
+        == datetime.datetime(2025, 8, 15, 11, 5, 51, tzinfo=datetime.timezone.utc).timestamp()
+    )
+
 
 @pytest.mark.skip(reason="workload tests not needed for K8s")
 def test_run_bin_command_args(patched_exec):


### PR DESCRIPTION
Fixes https://github.com/canonical/kafka-k8s-operator/issues/208