### PR TITLE
docs: Migrate improvements from 3/edge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,11 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'terraform/**'
+      - '.gitignore'
   schedule:
     - cron: '53 0 * * *'  # Daily at 00:53 UTC
   # Triggered on push to branch "main" by .github/workflows/release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths-ignore:
       - 'docs/**'
+      - '**.md'
 
 jobs:
   tag:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CharmHub Badge](https://charmhub.io/kafka-k8s/badge.svg)](https://charmhub.io/kafka-k8s)
 [![Release](https://github.com/canonical/kafka-k8s-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/kafka-k8s-operator/actions/workflows/release.yaml)
 [![Tests](https://github.com/canonical/kafka-k8s-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/kafka-k8s-operator/actions/workflows/ci.yaml?query=branch%3Amain)
-[![Docs](https://github.com/canonical/kafka-k8s-operator/actions/workflows/sync_docs.yaml/badge.svg)](https://github.com/canonical/kafka-k8s-operator/actions/workflows/sync_docs.yaml)
+[![Docs](https://readthedocs.com/projects/canonical-charmed-kafka-k8s/badge/?version=4)](https://app.readthedocs.com/projects/canonical-charmed-kafka-k8s/builds/?version__slug=4)
 
 ## Overview
 


### PR DESCRIPTION
Migrating some changes from 3/edge:

- CI update to avoid running non-docs tests for docs changes
- Update README docs badge to track RTD of the correct badge (will be working as soon as we make v.4 docs public)