### PR TITLE
docs: Update charmhub links

### DIFF
--- a/docs/how-to/deploy/deploy-anywhere.md
+++ b/docs/how-to/deploy/deploy-anywhere.md
@@ -6,7 +6,7 @@ For specific guides, see: [AKS](how-to-deploy-deploy-on-aks) and [EKS](how-to-de
 (how-to-deploy-deploy-anywhere)=
 
 ```{caution}
-For non-K8s Charmed Apache Apache Kafka, see the [Charmed Apache Kafka documentation](https://charmhub.io/kafka) instead.
+For non-K8s Charmed Apache Apache Kafka, see the [Charmed Apache Kafka documentation](https://documentation.ubuntu.com/charmed-kafka/3/) instead.
 ```
 
 To deploy a Charmed Apache Kafka K8s cluster:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 (index)=
 
 ```{note}
-This is a **Kubernetes** operator. To deploy on IAAS/VM, see [Charmed Apache Kafka operator](https://charmhub.io/kafka).
+This is a **Kubernetes** operator. To deploy on IAAS/VM, see [Charmed Apache Kafka operator](https://documentation.ubuntu.com/charmed-kafka/3/).
 ```
 
 # Charmed Apache Kafka K8s documentation

--- a/docs/reference/release-notes/revision-56-51.md
+++ b/docs/reference/release-notes/revision-56-51.md
@@ -4,7 +4,7 @@
 
 Charmed Apache Kafka K8s and Charmed Apache ZooKeeper K8s have been released for General Availability.
 
-[Charmhub](https://charmhub.io/kafka) | [Deploy guide](how-to-deploy-index) | [Upgrade instructions](how-to-upgrade) | [System requirements](reference-requirements)
+[Charmhub](https://charmhub.io/kafka-k8s) | [Deploy guide](how-to-deploy-index) | [Upgrade instructions](how-to-upgrade) | [System requirements](reference-requirements)
 
 ## Features
 

--- a/docs/tutorial/integrate-with-client-applications.md
+++ b/docs/tutorial/integrate-with-client-applications.md
@@ -73,7 +73,7 @@ Save the value listed under `bootstrap-server`, `username` and `password`. *(Not
 
 ## Produce/consume messages
 
-We will now use the username and password to produce some messages to Apache Kafka. To do so, we will first deploy the Apache Kafka Test App (available [here](https://charmhub.io/kafka-test-app)): a test charm that also bundles some Python scripts to push data to Apache Kafka, e.g.:
+We will now use the username and password to produce some messages to Apache Kafka. To do so, we will first deploy the [Apache Kafka Test App](https://charmhub.io/kafka-test-app): a test charm that also bundles some Python scripts to push data to Apache Kafka, e.g.:
 
 ```shell
 juju deploy kafka-test-app -n1 --channel edge


### PR DESCRIPTION
Updated charmhub links: replace documentation links with RTD, and make sure all the rest are correct.